### PR TITLE
spencer_people_tracking: 1.0.5-0 in 'kinetic/iliad-dist.yaml' [bloom]

### DIFF
--- a/kinetic/iliad-dist.yaml
+++ b/kinetic/iliad-dist.yaml
@@ -48,7 +48,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas/spencer_people_tracking.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/lcas/spencer_people_tracking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `spencer_people_tracking` to `1.0.5-0`:

- upstream repository: https://github.com/lcas/spencer_people_tracking.git
- release repository: https://github.com/lcas/spencer_people_tracking.git
- distro file: `kinetic/iliad-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.0.4-0`

## pcl_people_detector

- No changes

## rwth_ground_hog

- No changes

## rwth_ground_plane

- No changes

## rwth_perception_people_msgs

- No changes

## rwth_upper_body_detector

- No changes

## spencer_bagfile_tools

- No changes

## spencer_control_msgs

- No changes

## spencer_detected_person_association

- No changes

## spencer_detected_person_conversion

- No changes

## spencer_diagnostics

- No changes

## spencer_group_tracking

- No changes

## spencer_human_attribute_msgs

- No changes

## spencer_leg_detector_wrapper

- No changes

## spencer_people_tracking_launch

- No changes

## spencer_perception_mocks

- No changes

## spencer_social_relation_msgs

- No changes

## spencer_social_relations

- No changes

## spencer_tracking_metrics

- No changes

## spencer_tracking_msgs

- No changes

## spencer_tracking_rviz_plugin

- No changes

## spencer_tracking_utils

- No changes

## spencer_vision_msgs

- No changes

## srl_laser_detectors

- No changes

## srl_laser_features

- No changes

## srl_laser_segmentation

- No changes

## srl_nearest_neighbor_tracker

- No changes

## srl_tracking_exporter

- No changes

## srl_tracking_logfile_import

- No changes

## track_annotation_tool

```
* Merge branch 'master' of https://github.com/lcas/spencer_people_tracking
* added qt4-dev dep
* Contributors: Marc Hanheide
```

## video_to_bagfile

- No changes
