### PR TITLE
sandbox: 0.0.11-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -83,7 +83,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/sandbox-release.git
-      version: 0.0.5-0
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/LCAS/sandbox.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sandbox` to `0.0.11-0`:

- upstream repository: https://github.com/LCAS/sandbox.git
- release repository: https://github.com/LCAS/sandbox-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.5-0`

## catkin_test_pkg

- No changes
