### PR TITLE
oru_navigation: 0.0.4-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -63,7 +63,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/oru_navigation_release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `oru_navigation` to `0.0.4-0`:

- upstream repository: https://github.com/OrebroUniversity/navigation_oru-release.git
- release repository: https://github.com/LCAS/oru_navigation_release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.3-0`

## cititruck_description

- No changes

## cititruck_gazebo

- No changes

## cititruck_teleop

- No changes

## euro_pallet

- No changes

## gazebo_models_oru

- No changes

## gazebo_plugins_oru

- No changes

## gazebo_worlds_oru

- No changes

## navigation_oru

- No changes

## orunav_constraint_extract

- No changes

## orunav_conversions

- No changes

## orunav_coordinator_fake

- No changes

## orunav_debug

- No changes

## orunav_fork_control

- No changes

## orunav_generic

- No changes

## orunav_geometry

- No changes

## orunav_launch

- No changes

## orunav_motion_planner

- No changes

## orunav_mpc

- No changes

## orunav_msgs

- No changes

## orunav_node_utils

- No changes

## orunav_pallet_detection_sdf

- No changes

## orunav_params

- No changes

## orunav_path_pool

- No changes

## orunav_path_smoother

- No changes

## orunav_rosbag_tools

- No changes

## orunav_rviz

- No changes

## orunav_trajectory_processor

- No changes

## orunav_vehicle_execution

- No changes
