### PR TITLE
bayes_tracking: 1.0.8-0 in 'indigo/lcas-dist.yaml' [bloom]

### DIFF
--- a/indigo/lcas-dist.yaml
+++ b/indigo/lcas-dist.yaml
@@ -17,6 +17,12 @@ repositories:
       url: https://github.com/LCAS/acado.git
       version: stable
     status: maintained
+  bayes_tracking:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/lcas-releases/bayestracking.git
+      version: 1.0.8-0
   lcas_teaching:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `bayes_tracking` to `1.0.8-0`:

- upstream repository: https://github.com/LCAS/bayestracking.git
- release repository: https://github.com/lcas-releases/bayestracking.git
- distro file: `indigo/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## bayes_tracking

```
* added cv_bridge to catkin build (#18 <https://github.com/LCAS/bayestracking/issues/18>)
* Tracking NN including labels (#13 <https://github.com/LCAS/bayestracking/issues/13>)
  * Tracking NN including labels
  without auto formatting
  * Implimented NN_LABELED
  Restored default behaviour implimented another association algorithm
  * Included NN_LABEL in Association Matrix
  * correct mistyped word
  * NNJPDA_LABEL implimented
  * Added seq_size and seq_time
* Contributors: Marc Hanheide, Peter Lightbody
```
