### PR TITLE
oru_navigation: 0.1.2-0 in 'indigo/lcas-dist.yaml' [bloom]

### DIFF
--- a/indigo/lcas-dist.yaml
+++ b/indigo/lcas-dist.yaml
@@ -75,7 +75,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/LCAS/oru_navigation_release.git
-      version: 0.0.10-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/OrebroUniversity/navigation_oru-release.git


### PR DESCRIPTION
Increasing version of package(s) in repository `oru_navigation` to `0.1.2-0`:

- upstream repository: https://github.com/OrebroUniversity/navigation_oru-release.git
- release repository: https://github.com/LCAS/oru_navigation_release.git
- distro file: `indigo/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.10-0`

## cititruck_description

- No changes

## cititruck_gazebo

- No changes

## cititruck_teleop

- No changes

## euro_pallet

- No changes

## gazebo_models_oru

- No changes

## gazebo_plugins_oru

```
* Revert "changed to gazebo8"
  This reverts commit 3ab9b3f35bdabdff87abd911a6b9f208883179e9.
* Contributors: Marc Hanheide
```

## gazebo_worlds_oru

- No changes

## navigation_oru

- No changes

## orunav_constraint_extract

- No changes

## orunav_conversions

- No changes

## orunav_coordinator_fake

- No changes

## orunav_debug

- No changes

## orunav_fork_control

- No changes

## orunav_generic

- No changes

## orunav_geometry

- No changes

## orunav_launch

- No changes

## orunav_motion_planner

- No changes

## orunav_mpc

```
* Revert "changed to gazebo8"
  This reverts commit 3ab9b3f35bdabdff87abd911a6b9f208883179e9.
* Contributors: Marc Hanheide
```

## orunav_msgs

- No changes

## orunav_node_utils

- No changes

## orunav_pallet_detection_sdf

- No changes

## orunav_params

- No changes

## orunav_path_pool

- No changes

## orunav_path_smoother

- No changes

## orunav_rosbag_tools

- No changes

## orunav_rviz

- No changes

## orunav_trajectory_processor

- No changes

## orunav_vehicle_execution

- No changes
