### PR TITLE
turtlebot_apps: 2.3.9-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -245,6 +245,18 @@ repositories:
       version: master
     status: developed
   turtlebot_apps:
+    release:
+      packages:
+      - turtlebot_actions
+      - turtlebot_apps
+      - turtlebot_calibration
+      - turtlebot_follower
+      - turtlebot_navigation
+      - turtlebot_rapps
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/turtlebot_apps.git
+      version: 2.3.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_apps` to `2.3.9-0`:

- upstream repository: https://github.com/lcas/turtlebot_apps.git
- release repository: https://github.com/lcas-releases/turtlebot_apps.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
