### PR TITLE
turtlebot_simulator: 2.2.3-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -264,6 +264,16 @@ repositories:
       version: indigo
     status: maintained
   turtlebot_simulator:
+    release:
+      packages:
+      - turtlebot_gazebo
+      - turtlebot_simulator
+      - turtlebot_stage
+      - turtlebot_stdr
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/turtlebot_simulator.git
+      version: 2.2.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `turtlebot_simulator` to `2.2.3-0`:

- upstream repository: https://github.com/lcas/turtlebot_simulator.git
- release repository: https://github.com/lcas-releases/turtlebot_simulator.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## turtlebot_gazebo

```
* fixed maintainers
* prepared for name spaces
* fixing indention
* Update amcl_demo.launch
* remove backup files
* Fix changing amcl.launch.xml and gmapping.launch.xml locations under turtlebot_navigation
* Contributors: Marc Hanheide, Mohamed Al Zaiady, Mohamed Elzaiady, Tully Foote, mzaiady
```

## turtlebot_simulator

```
* fixed maintainers
* Contributors: Marc Hanheide
```

## turtlebot_stage

```
* fixed maintainers
* Fixed amcl include path
  Fixed include path for turtlebot_navigation/launch/includes/amcl/amcl.launch.xml. https://github.com/turtlebot/turtlebot_apps/commit/cc2671666e8529677e6757fe78de4ff625f946e5
* Contributors: Clyde McQueen, Marc Hanheide
```

## turtlebot_stdr

```
* fixed maintainers
* Contributors: Marc Hanheide
```
