### PR TITLE
lcas_teaching: 0.1.18-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -64,7 +64,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/lcas_teaching.git
-      version: 0.1.17-0
+      version: 0.1.18-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lcas_teaching` to `0.1.18-0`:

- upstream repository: https://github.com/LCAS/teaching.git
- release repository: https://github.com/strands-project-releases/lcas_teaching.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.17-0`

## catkinized_downward

- No changes

## uol_cmp3641m

- No changes

## uol_turtlebot_common

- No changes

## uol_turtlebot_simulator

```
* changed to new kinetic launch style
* Contributors: Marc Hanheide
```
