### PR TITLE
scitos_common: 0.1.12-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -182,6 +182,15 @@ repositories:
       version: hydro-devel
     status: developed
   scitos_common:
+    release:
+      packages:
+      - scitos_common
+      - scitos_description
+      - scitos_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/scitos_common.git
+      version: 0.1.12-0
     source:
       test_commits: true
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_common` to `0.1.12-0`:

- upstream repository: https://github.com/strands-project/scitos_common.git
- release repository: https://github.com/strands-project-releases/scitos_common.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## scitos_common

- No changes

## scitos_description

- No changes

## scitos_msgs

- No changes
