### PR TITLE
sicks300: 1.0.6-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -207,6 +207,11 @@ repositories:
       version: kinetic-devel
     status: developed
   sicks300:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/sicks300.git
+      version: 1.0.6-0
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `sicks300` to `1.0.6-0`:

- upstream repository: https://github.com/strands-project/sicks300.git
- release repository: https://github.com/strands-project-releases/sicks300.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## sicks300

```
* removed external maintainer
* Contributors: Marc Hanheide
```
