### PR TITLE
mongodb_store: 0.2.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -79,6 +79,16 @@ repositories:
       version: master
     status: developed
   mongodb_store:
+    release:
+      packages:
+      - libmongocxx_ros
+      - mongodb_log
+      - mongodb_store
+      - mongodb_store_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/mongodb_store.git
+      version: 0.2.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.2.0-0`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## libmongocxx_ros

```
* attempt to fix the cmake hell
* fixed install problem
* some attempts to build libmongocxx internally
* Contributors: Marc Hanheide
```

## mongodb_log

```
* dependencies fixing
* indigo-0.1.30
* updated Changelogs
* indigo-0.1.29
* updated Changelogs
* indigo-0.1.28
* updated Changelogs
* indigo-0.1.27
* updated Changelogs
* Contributors: Marc Hanheide, Nick Hawes
```

## mongodb_store

```
* dependencies fixing
* some attempts to build libmongocxx internally
* indigo-0.1.30
* updated Changelogs
* [package.xml] Add link to devel repository
  Without this, from [the package's wiki page](http://wiki.ros.org/mongodb_store) there's no way to tell where the repo is.
* fixing error with launching mongodb_store
* indigo-0.1.29
* updated Changelogs
* Support local datacentre timeout
  The timeout for the datacentre was hardcoded to 10 seconds. However, in
  some environments, for example in a cloud setup, this may not be enough.
  Make this configurable and just default to the previous 10 seconds.
* Merge pull request #188 <https://github.com/strands-project/mongodb_store/issues/188> from hkaraoguz/projectionerrorfix
  Projectionerrorfix
* Fixed updateClient assignment on copy.
* The projection tests are changed
* Revert back to original mongodb cmd
* [mongodb_store/stests/message_store_cpp_test.cpp] fix test for non-wait insert
* Fixed projection error happening when exclude and include field directives are mixed
* [mongodb_store] add test for non-wait insert
* [mongodb_store] add non-wait insert functionality
* indigo-0.1.28
* updated Changelogs
* Mongo C++ header location not exposed.
  Implemented fix from @ronwalf closes #176 <https://github.com/strands-project/mongodb_store/issues/176>
* Fixed missing return value
* Fixing the compatibility issues of messagestore cpp client with old SOMA versions
* Fixed issue with projection query including fields instead of excluding
* indigo-0.1.27
* updated Changelogs
* [mongodb_store/scripts/mongodb_server.py] connect with localhost when shutdown server
* Fixed if statement
* geotype of ROI has been added
* The geospatial indexing of SOMA ROI objects is added
* Contributors: Ferdian Jovan, Hakan, Isaac I.Y. Saito, Justin Huang, Marc Hanheide, Nick Hawes, Tim Niemueller, Yuki Furuta
```

## mongodb_store_msgs

```
* indigo-0.1.30
* updated Changelogs
* indigo-0.1.29
* updated Changelogs
* [mongodb_store_msgs] add Insert.msg
* indigo-0.1.28
* updated Changelogs
* indigo-0.1.27
* updated Changelogs
* Contributors: Nick Hawes, Yuki Furuta
```
