### PR TITLE
mongodb_store: 0.2.2-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -79,6 +79,16 @@ repositories:
       version: master
     status: developed
   mongodb_store:
+    release:
+      packages:
+      - libmongocxx_ros
+      - mongodb_log
+      - mongodb_store
+      - mongodb_store_msgs
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/mongodb_store.git
+      version: 0.2.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.2.2-0`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## libmongocxx_ros

```
* fixed wrong install place
* Contributors: Marc Hanheide
```

## mongodb_log

- No changes

## mongodb_store

- No changes

## mongodb_store_msgs

- No changes
