### PR TITLE
scitos_drivers: 0.2.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -210,6 +210,17 @@ repositories:
       version: indigo-devel
     status: developed
   scitos_drivers:
+    release:
+      packages:
+      - flir_pantilt_d46
+      - scitos_bringup
+      - scitos_drivers
+      - scitos_mira
+      - scitos_pc_monitor
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/scitos_drivers.git
+      version: 0.2.0-0
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_drivers` to `0.2.0-0`:

- upstream repository: https://github.com/strands-project/scitos_drivers.git
- release repository: https://github.com/strands-project-releases/scitos_drivers.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## flir_pantilt_d46

```
* changelogs
* changed maintainer from Chris to Marc
* Contributors: Marc Hanheide
* changed maintainer from Chris to Marc
* Contributors: Marc Hanheide
```

## scitos_bringup

```
* removed odometry_mileage as it caused a cyclic dependency
* changelogs
* Contributors: Marc Hanheide
```

## scitos_drivers

```
* changelogs
* changed maintainer from Chris to Marc
* Contributors: Marc Hanheide
* changed maintainer from Chris to Marc
* Contributors: Marc Hanheide
```

## scitos_mira

```
* added qt4 dep
* changelogs
* changed maintainer from Chris to Marc
* modifications required for new MIRA and Kinetic, plus setting MIRA_PATH from setup.bash
* MotorReset enabled
  fixes https://github.com/strands-project/scitos_robot/issues/77
* Contributors: Marc Hanheide
* changed maintainer from Chris to Marc
* modifications required for new MIRA and Kinetic, plus setting MIRA_PATH from setup.bash
* MotorReset enabled
  fixes https://github.com/strands-project/scitos_robot/issues/77
* Contributors: Marc Hanheide
```

## scitos_pc_monitor

```
* changelogs
* changed maintainer from Chris to Marc
* Contributors: Marc Hanheide
* changed maintainer from Chris to Marc
* Contributors: Marc Hanheide
```
