### PR TITLE
scitos_apps: 0.1.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -185,6 +185,20 @@ repositories:
       version: hydro-devel
     status: developed
   scitos_apps:
+    release:
+      packages:
+      - ptu_follow_frame
+      - scitos_apps
+      - scitos_cmd_vel_mux
+      - scitos_dashboard
+      - scitos_docking
+      - scitos_ptu
+      - scitos_teleop
+      - scitos_touch
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/scitos_apps.git
+      version: 0.1.1-0
     source:
       test_commits: false
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_apps` to `0.1.1-0`:

- upstream repository: https://github.com/strands-project/scitos_apps.git
- release repository: https://github.com/strands-project-releases/scitos_apps.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## ptu_follow_frame

- No changes

## scitos_apps

- No changes

## scitos_cmd_vel_mux

- No changes

## scitos_dashboard

- No changes

## scitos_docking

```
* Merge pull request #157 <https://github.com/strands-project/scitos_apps/issues/157> from gestom/hydro-devel
  Docking ends up in a 'safe' position
* Docking end up far away from station in the case of a timeout
* Safe timeout
* Contributors: Christian Dondrup, Nick Hawes, Tom Krajnik
```

## scitos_ptu

- No changes

## scitos_teleop

- No changes

## scitos_touch

- No changes
