### PR TITLE
scitos_apps: 0.1.2-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -198,7 +198,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_apps.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_apps` to `0.1.2-0`:

- upstream repository: https://github.com/strands-project/scitos_apps.git
- release repository: https://github.com/strands-project-releases/scitos_apps.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.1-0`

## ptu_follow_frame

- No changes

## scitos_apps

- No changes

## scitos_cmd_vel_mux

- No changes

## scitos_dashboard

- No changes

## scitos_docking

```
* added missing opencv dependency
* Contributors: Marc Hanheide
```

## scitos_ptu

- No changes

## scitos_teleop

- No changes

## scitos_touch

- No changes
