### PR TITLE
strands_movebase: 0.0.23-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -312,6 +312,18 @@ repositories:
       version: master
     status: developed
   strands_movebase:
+    release:
+      packages:
+      - calibrate_chest
+      - movebase_state_service
+      - param_loader
+      - strands_description
+      - strands_movebase
+      - strands_navfn
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_movebase.git
+      version: 0.0.23-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_movebase` to `0.0.23-0`:

- upstream repository: https://github.com/strands-project/strands_movebase.git
- release repository: https://github.com/strands-project-releases/strands_movebase.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## calibrate_chest

- No changes

## movebase_state_service

- No changes

## param_loader

- No changes

## strands_description

- No changes

## strands_movebase

```
* Added proper install target for subsampling nodelet
* Contributors: Nils Bore
```

## strands_navfn

- No changes
