### PR TITLE
strands_webtools: 0.1.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -331,6 +331,11 @@ repositories:
       version: indigo-devel
     status: developed
   strands_webtools:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_webtools.git
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/strands-project/strands_webtools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_webtools` to `0.1.0-0`:

- upstream repository: https://github.com/strands-project/strands_webtools.git
- release repository: https://github.com/strands-project-releases/strands_webtools.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## strands_webtools

```
* changed mjpeg_server to web_video_server
* Contributors: Marc Hanheide
```
