### PR TITLE
twitter_bootstrap: 0.0.3-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -388,6 +388,18 @@ repositories:
       url: https://github.com/lcas/turtlebot_simulator.git
       version: indigo
     status: maintained
+  twitter_bootstrap:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/twitter_bootstrap.git
+      version: 0.0.3-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/strands-project/twitter_bootstrap.git
+      version: master
+    status: maintained
   whycon:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `twitter_bootstrap` to `0.0.3-0`:

- upstream repository: https://github.com/strands-project/twitter_bootstrap.git
- release repository: https://github.com/strands-project-releases/twitter_bootstrap.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`
