### PR TITLE
strands_ui: 0.1.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -338,6 +338,20 @@ repositories:
       version: indigo-devel
     status: developed
   strands_ui:
+    release:
+      packages:
+      - mary_tts
+      - mongodb_media_server
+      - music_player
+      - pygame_managed_player
+      - robot_talk
+      - sound_player_server
+      - strands_ui
+      - strands_webserver
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_ui.git
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/strands-project/strands_ui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_ui` to `0.1.0-0`:

- upstream repository: https://github.com/strands-project/strands_ui.git
- release repository: https://github.com/strands-project-releases/strands_ui.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## mary_tts

- No changes

## mongodb_media_server

- No changes

## music_player

- No changes

## pygame_managed_player

- No changes

## robot_talk

- No changes

## sound_player_server

- No changes

## strands_ui

- No changes

## strands_webserver

- No changes
