### PR TITLE
openni_wrapper: 0.0.11-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -108,6 +108,13 @@ repositories:
       url: https://github.com/strands-project/mongodb_store.git
       version: kinetic-devel
     status: developed
+  openni_wrapper:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/openni_wrapper.git
+      version: 0.0.11-0
+    status: maintained
   oru_navigation:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_wrapper` to `0.0.11-0`:

- upstream repository: https://github.com/strands-project/openni_wrapper.git
- release repository: https://github.com/strands-project-releases/openni_wrapper.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## openni_wrapper

- No changes
