### PR TITLE
strands_morse: 0.2.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -345,6 +345,18 @@ repositories:
       url: https://github.com/strands-project/strands_apps.git
       version: kinetic-devel
     status: maintained
+  strands_morse:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_morse.git
+      version: 0.2.0-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/strands-project/strands_morse.git
+      version: kinetic-devel
+    status: maintained
   strands_movebase:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.2.0-0`:

- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## strands_morse

```
* some changes required for kinetic
* Merge pull request #170 <https://github.com/strands-project/strands_morse/issues/170> from heuristicus/example
  Add routine configuration to the example
* add routine example
* add stuff to allow routine to run
* Merge pull request #169 <https://github.com/strands-project/strands_morse/issues/169> from heuristicus/example
  Basic example which follows documentation
* different topological maps for gmapping and png maps
* add example simulator from documentation
* Merge pull request #167 <https://github.com/strands-project/strands_morse/issues/167> from heuristicus/indigo-devel
  bham simulation works in a more standalone manner
* update 2d nav to work with topmap in rviz
* update bham topmap to current format
* Merge pull request #166 <https://github.com/strands-project/strands_morse/issues/166> from Jailander/indigo-devel
  Deployment simulations
* changes in walking group topological map
* adding topological maps fo y4 aaf simulation
* minor chenges in tsc simulation
* Merge pull request #164 <https://github.com/strands-project/strands_morse/issues/164> from jayyoung/indigo-devel
  Updated ALOOF environment
* Updated ALOOF environment
* new rooms
* Contributors: Jaime Pulido Fentanes, Jay, Marc Hanheide, Michal Staniaszek, Nick Hawes
```
