### PR TITLE
thin_navigation: 0.0.3-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -410,9 +410,9 @@ repositories:
   thin_navigation:
     release:
       tags:
-        release: release/indigo/{package}/{version}
+        release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/thin_navigation_release.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://bitbucket.org/mhanheide/thin_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `thin_navigation` to `0.0.3-0`:

- upstream repository: https://bitbucket.org/mhanheide/thin_navigation.git
- release repository: https://github.com/LCAS/thin_navigation_release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.2-0`

## thin_navigation

```
* added install targets
* Contributors: Marc Hanheide
```
