### PR TITLE
people_detection: 1.0.12-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -164,11 +164,23 @@ repositories:
       version: master
     status: developed
   people_detection:
+    release:
+      packages:
+      - face_detector
+      - leg_detector
+      - people
+      - people_msgs
+      - people_tracking_filter
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/people_detection.git
+      version: 1.0.12-0
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/lcas/people_detection.git
       version: kinetic-devel
+    status: maintained
   robomongo_ros:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `people_detection` to `1.0.12-0`:

- upstream repository: https://github.com/lcas/people_detection.git
- release repository: https://github.com/lcas-releases/people_detection.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## face_detector

```
* changelogs
* changed maintainer
* Added id to shown image (#43 <https://github.com/lcas/people_detection/issues/43>)
  * added id to shown image
  * added capability to switch on/off face id display
* Update hardcoded location of opencv
  Version changed to 3.2.0, unfortunately we need to hardcode the
  location for now.
* [face_detector][test common] Use newly introduced publishtest.
  Since the publish rate of the detected face varies every second because one of the persons in the bag file is moving, [publishtest](http://wiki.ros.org/rostest/Nodes#publishtest) should suit the best in this case.
  [face_detector][test common] Enable substitution in rosparam tag.
* [test] Cleaner namespace assignment.
  [face_detector][test common] Fix warning in .launch format.
  Fix namespace in testcases.
  Increase retry. .bag-based perceptional tests are hard to deterministic, so it makes sense to do this.
  Set param use_sim_time.
  [face_detector][test] hztest can be used for measureing no publishment. hzerror is not needed in that case.
  [face_detector][test] Specify test name. Pass all args.
  [face_detector][test] pass_all_args might require all args kept out of include tag.
  [face_detector][test] Specify test-name.
  [face_detector][test] Disable all tests other than rgbd. I couldn't figure out how to use launches other than face_detector.rgbdlaunch, after hours of trial on local machine. I leave that up to someone else.
  [face_detector][test] Detection using rgbd works with this config.
  [face_detector][test] Shorter test duration (bag files are less than 7 seconds).
  [face_detector][test] Shorter test_duration. We only need a second or so as long as we can confirm the designated topic is being published.
  [face_detector][test] rosbag play with clock and loop option.
* [face_detector] an obtuse fix to hardcoded path for Xenial with OpenCV 3.1.0.
* [test] Missing dependency.
* [test] Missing dependency.
* Contributors: Alessandro Francescon, Isaac I.Y. Saito, Karl D. Hansen, Marc Hanheide
* changed maintainer
* Added id to shown image (#43 <https://github.com/lcas/people_detection/issues/43>)
  * added id to shown image
  * added capability to switch on/off face id display
* Update hardcoded location of opencv
  Version changed to 3.2.0, unfortunately we need to hardcode the
  location for now.
* [face_detector][test common] Use newly introduced publishtest.
  Since the publish rate of the detected face varies every second because one of the persons in the bag file is moving, [publishtest](http://wiki.ros.org/rostest/Nodes#publishtest) should suit the best in this case.
  [face_detector][test common] Enable substitution in rosparam tag.
* [test] Cleaner namespace assignment.
  [face_detector][test common] Fix warning in .launch format.
  Fix namespace in testcases.
  Increase retry. .bag-based perceptional tests are hard to deterministic, so it makes sense to do this.
  Set param use_sim_time.
  [face_detector][test] hztest can be used for measureing no publishment. hzerror is not needed in that case.
  [face_detector][test] Specify test name. Pass all args.
  [face_detector][test] pass_all_args might require all args kept out of include tag.
  [face_detector][test] Specify test-name.
  [face_detector][test] Disable all tests other than rgbd. I couldn't figure out how to use launches other than face_detector.rgbdlaunch, after hours of trial on local machine. I leave that up to someone else.
  [face_detector][test] Detection using rgbd works with this config.
  [face_detector][test] Shorter test duration (bag files are less than 7 seconds).
  [face_detector][test] Shorter test_duration. We only need a second or so as long as we can confirm the designated topic is being published.
  [face_detector][test] rosbag play with clock and loop option.
* [face_detector] an obtuse fix to hardcoded path for Xenial with OpenCV 3.1.0.
* [test] Missing dependency.
* [test] Missing dependency.
* Contributors: Alessandro Francescon, Isaac I.Y. Saito, Karl D. Hansen, Marc Hanheide
```

## leg_detector

```
* changelogs
* changed maintainer
* added deps
* Remove dependency on people_msgs generation
  The dependency on the people_msgs package should be enough. This removes
  warnings for the leg_detector and people_tracking_filter when building
  with catkin_make_isolated and catkin build.
* Fix missing fuzzy prediction from opencv2
  In opencv3 the predict_prob method was removed from cv::ml::RTrees.
* Fix CvMat change in OpenCV3
  The cv::ml package has been rewritten. I just changed the code to
  accomodate the new api, maybe this does not conform to the way the new
  cv::ml should be used...
* Contributors: Karl D. Hansen, Marc Hanheide
* changed maintainer
* added deps
* Remove dependency on people_msgs generation
  The dependency on the people_msgs package should be enough. This removes
  warnings for the leg_detector and people_tracking_filter when building
  with catkin_make_isolated and catkin build.
* Fix missing fuzzy prediction from opencv2
  In opencv3 the predict_prob method was removed from cv::ml::RTrees.
* Fix CvMat change in OpenCV3
  The cv::ml package has been rewritten. I just changed the code to
  accomodate the new api, maybe this does not conform to the way the new
  cv::ml should be used...
* Contributors: Karl D. Hansen, Marc Hanheide
```

## people

```
* changelogs
* remove velocity tracker as it wont build on kinetic
* changed maintainer
* Revert "Remove no build packages from metapackage."
  This reverts commit 0bda254faade07474ee11dc952b0664ea4d1260e.
* Remove no build packages from metapackage.
* Contributors: David V. Lu!!, Karl D. Hansen, Marc Hanheide
* remove velocity tracker as it wont build on kinetic
* changed maintainer
* Revert "Remove no build packages from metapackage."
  This reverts commit 0bda254faade07474ee11dc952b0664ea4d1260e.
* Remove no build packages from metapackage.
* Contributors: David V. Lu!!, Karl D. Hansen, Marc Hanheide
```

## people_msgs

```
* changelogs
* changed maintainer
* Contributors: Marc Hanheide
* changed maintainer
* Contributors: Marc Hanheide
```

## people_tracking_filter

```
* changelogs
* changed maintainer
* Remove dependency on people_msgs generation
  The dependency on the people_msgs package should be enough. This removes
  warnings for the leg_detector and people_tracking_filter when building
  with catkin_make_isolated and catkin build.
* Contributors: Karl D. Hansen, Marc Hanheide
* changed maintainer
* Remove dependency on people_msgs generation
  The dependency on the people_msgs package should be enough. This removes
  warnings for the leg_detector and people_tracking_filter when building
  with catkin_make_isolated and catkin build.
* Contributors: Karl D. Hansen, Marc Hanheide
```
