### PR TITLE
strands_qsr_lib: 0.4.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -488,6 +488,15 @@ repositories:
       version: kinetic-devel
     status: developed
   strands_qsr_lib:
+    release:
+      packages:
+      - qsr_lib
+      - qsr_prob_rep
+      - strands_qsr_lib
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_qsr_lib.git
+      version: 0.4.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_qsr_lib` to `0.4.0-0`:

- upstream repository: https://github.com/strands-project/strands_qsr_lib.git
- release repository: https://github.com/strands-project-releases/strands_qsr_lib.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## qsr_lib

```
* changed maintainer to marc
* update the graphlets class - uses object type if provided in dynamic … (#233 <https://github.com/strands-project/strands_qsr_lib/issues/233>)
  * update the graphlets class - uses object type if provided in dynamic args
  * updated qstag for tcpp (creates a plane-object node, and rcc4, rcc5 (simple)
  * updated qstag for tcpp (creates a plane-object node, and rcc4, rcc5 (simple)
  * updated the median filter and returns empty qstag if nop timepoints in qsr world trace
  * updates to filters
  * updated qstag filters and episodes
  * noise threshold removed from episodes. Done by filter.
* Contributors: Marc Hanheide, Paul
```

## qsr_prob_rep

```
* changed maintainer to marc
* A little bit of error handling for incorrect model and state numbers. (#241 <https://github.com/strands-project/strands_qsr_lib/issues/241>)
* Merge pull request #236 <https://github.com/strands-project/strands_qsr_lib/issues/236> from cdondrup/noxml
  Removing the xml overhead from the HMM representations
* Merge pull request #3 <https://github.com/strands-project/strands_qsr_lib/issues/3> from pet1330/noxml
  member variable init when constructed
* member variable init when constructed
* Transforming test HMMs into new format.
  Adapted test script to work with new interface.
* Removing the hmm types active
* Adding script to transform old format HMMs into new format HMMs
* Merge pull request #2 <https://github.com/strands-project/strands_qsr_lib/issues/2> from pet1330/noxml
  Making the hmm lib thread safe. Especially for the generic HMM.
* Making the hmm lib thread safe. Especially for the generic HMM.
* Adapting example client to now hmm format.
* Removing xml overhead form hmm library. This was horrid to begin with.
  Using a dictionary of lists now.
* Contributors: Christian Dondrup, Marc Hanheide, Peter Lightbody
```

## strands_qsr_lib

```
* changed maintainer to marc
* Contributors: Marc Hanheide
```
