### PR TITLE
strands_morse: 0.2.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -409,7 +409,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.2.1-0`:

- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.0-0`

## strands_morse

```
* Merge pull request #171 <https://github.com/strands-project/strands_morse/issues/171> from bfalacerda/kinetic-devel
  launch tsc in fast mode
* launch tsc in fast mode
* Contributors: Bruno Lacerda, Nick Hawes
```
