### PR TITLE
mongodb_store: 0.3.3-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -108,7 +108,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.2.2-0
+      version: 0.3.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.3.3-0`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.2-0`

## libmongocxx_ros

- No changes

## mongodb_log

- No changes

## mongodb_store

```
* Merge pull request #200 <https://github.com/strands-project/mongodb_store/issues/200> from strands-project/shapeshifter
  mongodb_store: support shapeshifter
* Fixed missing space.
* mongodb_store: support shapeshifter
* Merge pull request #195 <https://github.com/strands-project/mongodb_store/issues/195> from mbeneto/kinetic-devel
  Added keep_trash parameter
* Added keep_trash parameter
  This parameter enables the user to select to store the items deleted into the trash (default) or not.
* Contributors: Furushchev, Nick Hawes, mbeneto
```

## mongodb_store_msgs

- No changes
