### PR TITLE
strands_executive: 1.2.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -384,6 +384,21 @@ repositories:
       version: kinetic-devel
     status: maintained
   strands_executive:
+    release:
+      packages:
+      - gcal_routine
+      - mdp_plan_exec
+      - prism_strands
+      - scheduler
+      - scipoptsuite
+      - sim_clock
+      - strands_executive_msgs
+      - task_executor
+      - wait_action
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_executive.git
+      version: 1.2.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `1.2.0-0`:

- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## gcal_routine

- No changes

## mdp_plan_exec

- No changes

## prism_strands

- No changes

## scheduler

- No changes

## scipoptsuite

- No changes

## sim_clock

- No changes

## strands_executive_msgs

- No changes

## task_executor

- No changes

## wait_action

- No changes
