### PR TITLE
mongodb_store: 0.3.4-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -108,7 +108,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.2.2-0
+      version: 0.3.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.3.4-0`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.2.2-0`

## libmongocxx_ros

- No changes

## mongodb_log

- No changes

## mongodb_store

- No changes

## mongodb_store_msgs

- No changes
