### PR TITLE
mongodb_store: 0.3.6-0 in 'indigo/lcas-dist.yaml' [bloom]

### DIFF
--- a/indigo/lcas-dist.yaml
+++ b/indigo/lcas-dist.yaml
@@ -42,6 +42,16 @@ repositories:
       version: indigo-devel
     status: developed
   mongodb_store:
+    release:
+      packages:
+      - libmongocxx_ros
+      - mongodb_log
+      - mongodb_store
+      - mongodb_store_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/mongodb_store.git
+      version: 0.3.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.3.6-0`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## libmongocxx_ros

- No changes

## mongodb_log

- No changes

## mongodb_store

- No changes

## mongodb_store_msgs

- No changes
