### PR TITLE
strands_executive: 1.0.9-0 in 'indigo/lcas-dist.yaml' [bloom]

### DIFF
--- a/indigo/lcas-dist.yaml
+++ b/indigo/lcas-dist.yaml
@@ -183,6 +183,27 @@ repositories:
       url: https://github.com/LCAS/sandbox.git
       version: master
     status: developed
+  strands_executive:
+    release:
+      packages:
+      - gcal_routine
+      - mdp_plan_exec
+      - scheduler
+      - scipoptsuite
+      - sim_clock
+      - strands_executive_msgs
+      - task_executor
+      - wait_action
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_executive.git
+      version: 1.0.9-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/strands-project/strands_executive.git
+      version: indigo-devel
+    status: developed
   thin_navigation:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `1.0.9-0`:

- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## gcal_routine

```
* indigo-1.0.8
* Updated changelogs
* Contributors: Nick Hawes
```

## mdp_plan_exec

```
* Removed stray prism-robots dependency.
* indigo-1.0.8
* Updated changelogs
* Contributors: Nick Hawes
```

## scheduler

```
* indigo-1.0.8
* Updated changelogs
* Contributors: Nick Hawes
```

## scipoptsuite

```
* indigo-1.0.8
* Updated changelogs
* Contributors: Nick Hawes
```

## sim_clock

```
* indigo-1.0.8
* Updated changelogs
* Contributors: Nick Hawes
```

## strands_executive_msgs

```
* indigo-1.0.8
* Updated changelogs
* Contributors: Nick Hawes
```

## task_executor

```
* indigo-1.0.8
* Updated changelogs
* Contributors: Nick Hawes
```

## wait_action

```
* indigo-1.0.8
* Updated changelogs
* Contributors: Nick Hawes
```
