### PR TITLE
strands_executive: 1.2.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -403,7 +403,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 1.2.0-0
+      version: 1.2.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `1.2.1-0`:

- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `1.2.0-0`

## gcal_routine

- No changes

## mdp_plan_exec

- No changes

## prism_strands

```
* remove bad dependency
* Contributors: Bruno Lacerda
```

## scheduler

- No changes

## scipoptsuite

- No changes

## sim_clock

- No changes

## strands_executive_msgs

- No changes

## task_executor

- No changes

## wait_action

- No changes
