### PR TITLE
iliad_smp: 0.0.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -76,7 +76,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://gitsvn-nt.oru.se/iliad/software/iliad_smp_releases.git
+      url: https://github.com/LCAS/restricted-releases.git
       version: 0.0.1-0
     source:
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_smp` to `0.0.1-0`:

- upstream repository: https://gitsvn-nt.oru.se/iliad/software/iliad_smp.git
- release repository: https://github.com/LCAS/restricted-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.1-0`

## iliad_smp

```
* adding the cfg directory
* removing the slasj
* removing planners which are not compatible with ompl 1.2.1, having a different branch for fixing bugs issues
* using rrt connect
* fixing the version number
* fixing bug, rotating footprint in the proper way
* fixing bug related to reading the status of the solution
* merging and fixing conflicts with v0.1 branch
* addin AUTHORS and CONTRIBUTORS files
* updating licenses
* returning path only if it exists
* selecting params
* fixing merge
* updating params
* including RRTsharp, cost thrs, simplifyMax for RRTConnect, removing useless states
* adding new set of parameters
* added license materials
* adding help infos to params
* allowing selection of the desired path planner from params
* removing useless header
* starting a new package to provide a mock-up system for car-like planning in the EU ILIAD Project
* Contributors: Luigi Palmieri, Palmieri Luigi (CR/AEG) VM, Palmieri Luigi (CR/AER)
```
