### PR TITLE
velodyne: 1.2.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -666,6 +666,16 @@ repositories:
       version: master
     status: developed
   velodyne:
+    release:
+      packages:
+      - velodyne
+      - velodyne_driver
+      - velodyne_msgs
+      - velodyne_pointcloud
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/LCAS/velodyne-release.git
+      version: 1.2.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne` to `1.2.1-0`:

- upstream repository: https://github.com/OrebroUniversity/velodyne.git
- release repository: https://github.com/LCAS/velodyne-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `null`

## velodyne

- No changes

## velodyne_driver

```
* Correct VLP-16 packet rate error.
* Use port number when reading PCAP data.
* Fix g++ 5.3.1 compiler errors.
* Add dynamic_reconfigure and time_offset correction.
* Make input destructors virtual.
* Add VLP-16 support.
* Add support for multiple devices.
* Contributors: Brice Rebsamen, ddillenberger, Patrick Hussey, Andreas
  Wachaja, priyankadey, Jack O'Quin
```

## velodyne_msgs

- No changes

## velodyne_pointcloud

```
* Fix compile warning for "Wrong initialization order".
* Fix unit tests for transform nodelet.
* Provide dynamic reconfiguration for TransformNodelet (#78 <https://github.com/ros-drivers/velodyne/pull/78>).
* Allow ``min_range`` as short as 0.4m.
* Add VLP-16 support (#44 <https://github.com/ros-drivers/velodyne/pull/44>).
* Fix several errors in point computations (#43 <https://github.com/ros-drivers/velodyne/pull/43>, #47 <https://github.com/ros-drivers/velodyne/pull/47>, #50 <https://github.com/ros-drivers/velodyne/issue/50>,
  #55 <https://github.com/ros-drivers/velodyne/pull/55>, #76 <https://github.com/ros-drivers/velodyne/pull/76>).
* Fix several calibration file problems (#41 <https://github.com/ros-drivers/velodyne/pull/41>, #42 <https://github.com/ros-drivers/velodyne/pull/42>).
* Contributors: Bo Li, Patrick Hussey, William Woodall, Kun Li,
  lemiant, Jose Luis Blanco-Claraco, Alexander Schaefer, François
  Pomerleau, Andreas Wachaja, Jack O'Quin
```
