### PR TITLE
iliad_distribution: 0.0.4-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -56,10 +56,13 @@ repositories:
     status: developed
   iliad_distribution:
     release:
+      packages:
+      - iliad_distribution
+      - iliad_restricted
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/iliad_distribution.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://gitsvn-nt.oru.se/iliad/software/iliad_metapackage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_distribution` to `0.0.4-0`:

- upstream repository: https://gitsvn-nt.oru.se/iliad/software/iliad_metapackage.git
- release repository: https://github.com/lcas-releases/iliad_distribution.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.0.3-0`

## iliad_distribution

- No changes

## iliad_restricted

```
* added restricted distribution
* Contributors: Marc Hanheide
```
