### PR TITLE
kmo_interfaces: 0.0.4-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -110,7 +110,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/iliad-project/kmo_interfaces-release.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       test_pull_requests: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kmo_interfaces` to `0.0.4-0`:

- upstream repository: https://gitsvn-nt.oru.se/marc-hanheide/kmo_interfaces.git
- release repository: https://github.com/iliad-project/kmo_interfaces-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.1`
- previous version for package: `0.0.3-0`

## kmo_cpi_interface

- No changes

## kmo_fork_control

- No changes

## kmo_navserver

```
* Added tf_prefix workaround.
* tf_prefix fix.
* Merged conflicts.
* Added onboard launch files.
* Launchfile for onbard computer.
* Contributors: Henrik Andreasson
```

## sick_s3x

- No changes
