### PR TITLE
iliad_human_perception: 1.0.1-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -75,7 +75,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception_release.git
-      version: 1.0.1-0
+      version: 1.0.1-1
     source:
       type: git
       url: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_human_perception` to `1.0.1-1`:

- upstream repository: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception_release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.0.1-0`

## iliad_human_perception_launch

```
* Added ROS multimaster to human perception
* Relaying of detector/tracker output topics
* README instructions updated
* First version of people detection and tracking in 2D laser, still requires fix to srl_laser_segmentation and srl_laser_detectors ROS interface
* Fix previous commit, somehow rospy.Rate() causes latency
* Limit publish rate of groundtruth tracked persons to 30 Hz (was 1000 Hz)
* Bugfixes
* Restructuring launch files; script to publish groundtruth tracks from Gazebo
* Initial version of iliad_human_perception_launch, untested
* Contributors: Gogs, Linder Timm
```
