### PR TITLE
rasberry: 0.0.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -245,6 +245,16 @@ repositories:
       version: catkinised
     status: developed
   rasberry:
+    release:
+      packages:
+      - rasberry
+      - rasberry_des
+      - rasberry_gazebo
+      - rasberry_navigation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/rasberry.git
+      version: 0.0.1-0
     source:
       test_pull_requests: true
       type: git
@@ -645,13 +655,6 @@ repositories:
       url: https://github.com/strands-project/strands_webtools.git
       version: kinetic-devel
     status: developed
-  thorvald:
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/lcas/thorvald.git
-      version: kinetic-devel
-    status: developed
   thin_navigation:
     release:
       tags:
@@ -662,6 +665,13 @@ repositories:
       type: git
       url: https://bitbucket.org/mhanheide/thin_navigation.git
       version: master
+    status: developed
+  thorvald:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/lcas/thorvald.git
+      version: kinetic-devel
     status: developed
   turtlebot_apps:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `rasberry` to `0.0.1-0`:

- upstream repository: https://github.com/LCAS/RASberry.git
- release repository: https://github.com/lcas-releases/rasberry.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## rasberry

```
* added meta package
* Contributors: Marc Hanheide
```

## rasberry_des

```
* Modified the Picker class to publish /<picker_name>/pose (geometry_msgs.msg.Pose) topic when it reaches a node.
  Ros topics were not published while runnning quick sim (simpy.Environment), probably too fast. This needs double checking.
* Changes:
  1. env.step() is called in a while loop checking rospy.is_shutdown(), rather than env.run().
  2. A bug in the Picker is fixed. The picker no longer re-pick the same row, after it is completed and scheduler_monitor process has not allocated a new row.
* Change(s):
  1. Modified into a rospackage with one node pickers_only.py
  2. Node initialisation is the only ros functionality at this stage.
  3. Farm and Picker classes defined in pickers_only.py are moved into individual files(farm.py and picker.py)
  Known Issue(s):
  1. SimPy processes are not interrupted by Ctrl+c killing the node.
* Initial commit of the discrete event simulation of a strawberry farm.
  This simulates only pickers and a farm allocation monitoring process.
* Contributors: gpdas
```

## rasberry_gazebo

```
* skeleton for RASberry simulation
* Contributors: Marc Hanheide
```

## rasberry_navigation

```
* navigation added
* Contributors: Marc Hanheide
```
