### PR TITLE
thorvald: 0.0.1-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -682,7 +682,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/thorvald-releases.git
-      version: 0.0.1-0
+      version: 0.0.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `0.0.1-1`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/LCAS/thorvald-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.0.1-0`

## thorvald_2dnav

```
* added email to package.xml
* added robot in thorvald_model
* added parts to xacro and made more robots
* back from greenhouseot
* initial commit
* Contributors: larsgrim
```

## thorvald_base

```
* Merge branch 'kinetic-devel' of https://github.com/LCAS/Thorvald into kinetic-devel
* added a few install targets already
  this partially addresses #23 <https://github.com/LCAS/Thorvald/issues/23> but not entirely yet.
* creted gazebo model plugin
* creted gazebo model plugin
* modified include path in thorvald_can devices
* modified package.xml
* added email to package.xml
* added robot in thorvald_model
* added parts to xacro and made more robots
* changed some model related names and moved some model stuff around
* started commenting
* back from greenhouseot
* just another commit
* created thorvald_model and moved model stuff to it
* initial commit
* Contributors: Marc Hanheide, larsgrim
```

## thorvald_bringup

```
* added email to package.xml
* changed default arguments for model.xacro and thorvald_bringup.launch
* added robot in thorvald_model
* added parts to xacro and made more robots
* changed some model related names and moved some model stuff around
* started commenting
* just another commit
* created thorvald_model and moved model stuff to it
* initial commit
* Contributors: larsgrim
```

## thorvald_can_devices

```
* creted gazebo model plugin
* modified include path in thorvald_can devices
* added some gazebo tags to thorvald_model.xacro and changed include dir in can_devices CMake
* modified package.xml
* added email to package.xml
* added robot in thorvald_model
* started commenting
* back from greenhouseot
* initial commit
* Contributors: larsgrim
```

## thorvald_gazebo_plugins

```
* Merge branch 'kinetic-devel' of https://github.com/LCAS/Thorvald into kinetic-devel
* added odometry and support for all current robots to simulation
* added a few install targets already
  this partially addresses #23 <https://github.com/LCAS/Thorvald/issues/23> but not entirely yet.
* wheel diameter is now used as such
* added email
* creted gazebo model plugin
* Contributors: Marc Hanheide, larsgrim
```

## thorvald_gui

```
* removed useless files
* back from greenhouseot
* initial commit
* Contributors: larsgrim
```

## thorvald_model

```
* added odometry and support for all current robots to simulation
* Merge branch 'kinetic-devel' of https://github.com/LCAS/Thorvald into kinetic-devel
* creted gazebo model plugin
* Merge pull request #21 <https://github.com/LCAS/Thorvald/issues/21> from Johnmenex/kinetic-devel
  Set collision values, and basic center of mass
* Set collision values, and basic center of mass
* modified include path in thorvald_can devices
* added some gazebo tags to thorvald_model.xacro and changed include dir in can_devices CMake
* added email to package.xml
* changed default arguments for model.xacro and thorvald_bringup.launch
* added temp inertias to model
* fixed paths for simple startup
* added robot in thorvald_model
* added parts to xacro and made more robots
* changed some model related names and moved some model stuff around
* started commenting
* back from greenhouseot
* just another commit
* created thorvald_model and moved model stuff to it
* Contributors: Johnmenex, Marc Hanheide, larsgrim
```

## thorvald_msgs

```
* added email to package.xml
* added parts to xacro and made more robots
* back from greenhouseot
* initial commit
* Contributors: larsgrim
```

## thorvald_teleop

```
* added email to package.xml
* fixed paths for simple startup
* back from greenhouseot
* initial commit
* Contributors: Marc Hanheide, larsgrim
```

## thorvald_twist_mux

```
* added email to package.xml
* back from greenhouseot
* just another commit
* initial commit
* Contributors: larsgrim
```
