### PR TITLE
thorvald: 0.0.4-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -682,7 +682,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/thorvald-releases.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `0.0.4-0`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/LCAS/thorvald-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.0.3-0`

## thorvald_2dnav

- No changes

## thorvald_base

```
* Merge branch 'kinetic-devel' of https://github.com/LCAS/Thorvald into kinetic-devel
* added dep
* Contributors: larsgrim
* Merge branch 'kinetic-devel' of https://github.com/LCAS/Thorvald into kinetic-devel
* added dep
* Contributors: larsgrim
* Merge branch 'kinetic-devel' of https://github.com/LCAS/Thorvald into kinetic-devel
* added dep
* Contributors: larsgrim
```

## thorvald_bringup

- No changes

## thorvald_can_devices

- No changes

## thorvald_gazebo_plugins

- No changes

## thorvald_gui

- No changes

## thorvald_model

- No changes

## thorvald_msgs

- No changes

## thorvald_teleop

- No changes

## thorvald_twist_mux

- No changes
