### PR TITLE
sicks300: 1.2.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -365,7 +365,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/sicks300.git
-      version: 1.0.6-0
+      version: 1.2.0-0
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `sicks300` to `1.2.0-0`:

- upstream repository: https://github.com/strands-project/sicks300.git
- release repository: https://github.com/strands-project-releases/sicks300.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.3`
- previous version for package: `1.0.6-0`

## sicks300

- No changes
