### PR TITLE
lcas_teaching: 0.1.19-0 in 'indigo/lcas-dist.yaml' [bloom]

### DIFF
--- a/indigo/lcas-dist.yaml
+++ b/indigo/lcas-dist.yaml
@@ -35,7 +35,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/lcas_teaching.git
-      version: 0.1.16-0
+      version: 0.1.19-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lcas_teaching` to `0.1.19-0`:

- upstream repository: https://github.com/LCAS/teaching.git
- release repository: https://github.com/strands-project-releases/lcas_teaching.git
- distro file: `indigo/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.1.16-0`

## catkinized_downward

```
* prepare indigo release
* 0.1.18
* updated changelogs
* 0.1.17
* changelogs
* Contributors: LCAS build farm, Marc Hanheide
* 0.1.18
* updated changelogs
* 0.1.17
* changelogs
* Contributors: LCAS build farm, Marc Hanheide
```

## uol_cmp3641m

```
* prepare indigo release
* 0.1.18
* updated changelogs
* 0.1.17
* changelogs
* Contributors: LCAS build farm, Marc Hanheide
* 0.1.18
* updated changelogs
* 0.1.17
* changelogs
* Contributors: LCAS build farm, Marc Hanheide
```

## uol_kobuki_gazebo_plugins

```
* ready for updates on indigo
* prepare indigo release
* Contributors: Marc Hanheide
```

## uol_morse_simulator

```
* ready for updates on indigo
* prepare indigo release
* Contributors: Marc Hanheide
```

## uol_turtlebot_common

```
* prepare indigo release
* 0.1.18
* updated changelogs
* 0.1.17
* changelogs
* removed map_store
  as it is not available in Kinetic (and not needed???)
* Contributors: LCAS build farm, Marc Hanheide
* 0.1.18
* updated changelogs
* 0.1.17
* changelogs
* removed map_store
  as it is not available in Kinetic (and not needed???)
* Contributors: LCAS build farm, Marc Hanheide
```

## uol_turtlebot_simulator

```
* change position of test arena target poles for assessment
* prepare indigo release
* 0.1.18
* updated changelogs
* 0.1.17
* changelogs
* Contributors: LCAS build farm, Marc Hanheide, paul-baxter
* 0.1.18
* updated changelogs
* 0.1.17
* changelogs
* Contributors: LCAS build farm, Marc Hanheide
```
