### PR TITLE
strands_navigation: 1.0.5-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -572,7 +572,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `1.0.5-0`:

- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.4-0`

## emergency_behaviours

```
* Updated email to new Oxford address
* Contributors: Nick Hawes
```

## joy_map_saver

- No changes

## message_store_map_switcher

```
* updated email
* Contributors: Nick Hawes
```

## monitored_navigation

- No changes

## nav_goals_generator

- No changes

## pose_initialiser

- No changes

## strands_navigation

- No changes

## strands_navigation_msgs

```
* Merge pull request #351 <https://github.com/strands-project/strands_navigation/issues/351> from heuristicus/indigo-devel
  Can now place nodes with RMB to stop automatic edge creation
* Can now place nodes with RMB to stop automatic edge creation
  Fix deletion dialogue, edges and tags were swapped
* Contributors: Michal Staniaszek, Nick Hawes
```

## topological_logging_manager

```
* Updated email to new Oxford address
* Contributors: Nick Hawes
```

## topological_navigation

```
* add speed based prediction to install scripts
* Merge pull request #342 <https://github.com/strands-project/strands_navigation/issues/342> from bfalacerda/predictions
  optimistic nav predictions until 10 samples
* Merge pull request #351 <https://github.com/strands-project/strands_navigation/issues/351> from heuristicus/indigo-devel
  Can now place nodes with RMB to stop automatic edge creation
* Merge pull request #352 <https://github.com/strands-project/strands_navigation/issues/352> from heuristicus/patch-2
  Ensure that meta out is defined to prevent crashes
* Ensure that meta out is defined to prevent crashes
* Can now place nodes with RMB to stop automatic edge creation
  Fix deletion dialogue, edges and tags were swapped
* Merge pull request #350 <https://github.com/strands-project/strands_navigation/issues/350> from heuristicus/patch-1
  Fix crash on attempting to change node name
* Fix crash on attempting to change node name
* Merge pull request #349 <https://github.com/strands-project/strands_navigation/issues/349> from mudrole1/indigo-devel
  Adding waiting for the add_node service
* Removed loadMap() in the delete method
* optimistic predictions until 10 samples
* Merge branch 'prediction-hacking' of https://github.com/Jailander/strands_navigation into predictions
* creating optimistic predictions
* Contributors: Bruno Lacerda, Jaime Pulido Fentanes, Lenka Mudrova, Michal Staniaszek, Nick Hawes
```

## topological_rviz_tools

```
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_navigation into indigo-devel
* Merge pull request #353 <https://github.com/strands-project/strands_navigation/issues/353> from heuristicus/rviz_update
  Topological rviz tools topic names made more descriptive
* Merge pull request #351 <https://github.com/strands-project/strands_navigation/issues/351> from heuristicus/indigo-devel
  Can now place nodes with RMB to stop automatic edge creation
* more descriptive names for topics displayed in rviz
* Can now place nodes with RMB to stop automatic edge creation
  Fix deletion dialogue, edges and tags were swapped
* Merge pull request #349 <https://github.com/strands-project/strands_navigation/issues/349> from mudrole1/indigo-devel
  Adding waiting for the add_node service
* Adding waiting for services
* Update topological_edge_tool.cpp
* Adding waiting for the add_node service
* Merge pull request #348 <https://github.com/strands-project/strands_navigation/issues/348> from heuristicus/indigo-devel
  add standalone flag for when navigation is running
* Merge pull request #347 <https://github.com/strands-project/strands_navigation/issues/347> from mudrole1/indigo-devel
  Update strands_rviz_topmap.launch
* Update strands_rviz_topmap.launch
* add standalone flag for when navigation is running
* Contributors: Bruno Lacerda, Lenka Mudrova, Michal Staniaszek, Nick Hawes
```

## topological_utils

```
* Merge pull request #349 <https://github.com/strands-project/strands_navigation/issues/349> from mudrole1/indigo-devel
  Adding waiting for the add_node service
* Fixed two arguments
* Contributors: Lenka Mudrova, Nick Hawes
```
