### PR TITLE
iliad_smp: 0.1.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -90,10 +90,12 @@ repositories:
     status: developed
   iliad_smp:
     release:
+      packages:
+      - iliad_smp_global_planner
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/restricted-releases.git
-      version: 0.0.1-0
+      version: 0.1.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_smp` to `0.1.0-0`:

- upstream repository: https://gitsvn-nt.oru.se/palmieri/iliad_smp.git
- release repository: https://github.com/LCAS/restricted-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.1-0`

## iliad_smp_global_planner

```
* Adding bicycle state space to use the steering_functions package
* Providing example on how to launch the service
* Adding move_base global_planner plug-in
* Adding new cost bound param
* Adding new planners RRTX and RRT# and initial implementation of PS-RRT
* Adding ompl_visualization tool to display planner graph in RviZ
* Contributors: Palmieri Luigi (Robert Bosch GmbH, CR/AER)
```
