### PR TITLE
steering_functions: 1.0.4-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -443,7 +443,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/steering_functions.git
-      version: 1.0.2-0
+      version: 1.0.4-0
     source:
       test_commits: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `steering_functions` to `1.0.4-0`:

- upstream repository: https://github.com/iliad-project/steering_functions.git
- release repository: https://github.com/lcas-releases/steering_functions.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.2-0`

## steering_functions

```
* Merge branch 'iliad' of https://github.com/iliad-project/steering_functions into iliad
* fixed for hpp files
* Contributors: Marc Hanheide
```
