### PR TITLE
lcas_nav_branch: 2.0.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -120,6 +120,13 @@ repositories:
       version: master
     status: developed
   lcas_nav_branch:
+    release:
+      packages:
+      - dwa_local_planner_constraint
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/navigation-additions.git
+      version: 2.0.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lcas_nav_branch` to `2.0.0-0`:

- upstream repository: https://github.com/strands-project/navigation.git
- release repository: https://github.com/strands-project-releases/navigation-additions.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## dwa_local_planner_constraint

```
* removed duplicate
* more renames due to new package name
* Contributors: Marc Hanheide
```
