### PR TITLE
iliad_smp: 0.1.2-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -95,7 +95,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/restricted-releases.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_smp` to `0.1.2-0`:

- upstream repository: https://gitsvn-nt.oru.se/palmieri/iliad_smp.git
- release repository: https://github.com/LCAS/restricted-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.1-0`

## iliad_smp_global_planner

```
* Merge branch 'v0.1.0-branch'
* updating 3rd party license file
* extending list of params
* entering the service name as param
* example launch file for move_base plug in
* Merge branch 'v0.1.0-branch' of https://gitsvn-nt.oru.se/palmieri/iliad_smp into v0.1.0-branch
* Exporting all the targets properly
* Contributors: Luigi Palmieri (CR/AER)
```
