### PR TITLE
coordination_oru_ros: 0.2.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -30,10 +30,16 @@ repositories:
       version: master
     status: developed
   coordination_oru_ros:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/iliad-project/coordination_oru-release.git
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/FedericoPecora/coordination_oru_ros.git
       version: master
+    status: developed
   fremen:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `coordination_oru_ros` to `0.2.0-0`:

- upstream repository: https://github.com/FedericoPecora/coordination_oru_ros.git
- release repository: https://github.com/iliad-project/coordination_oru-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## coordination_oru_ros

```
* Merge branch 'master' of github.com:FedericoPecora/coordination_oru_ros
* changed install to include dependency packages
* Changed to RVizVisualization in NCFM main node
* Added RVIZVisualization in MainNode
* Updated to new version of coordination_oru (0.1.4)
* Now depends on snapshots of coordination_oru and metacsp
* Contributors: Federico Pecora, Marc Hanheide
* Merge branch 'master' of github.com:FedericoPecora/coordination_oru_ros
* changed install to include dependency packages
* Changed to RVizVisualization in NCFM main node
* Added RVIZVisualization in MainNode
* Updated to new version of coordination_oru (0.1.4)
* Now depends on snapshots of coordination_oru and metacsp
* Contributors: Federico Pecora, Marc Hanheide
```
