### PR TITLE
iliad_execution: 0.0.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -75,6 +75,14 @@ repositories:
       version: master
     status: developed
   iliad_execution:
+    release:
+      packages:
+      - iliad_executive
+      - iliad_topological
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://gitsvn-nt.oru.se/iliad/software/iliad_execution-releases.git
+      version: 0.0.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_execution` to `0.0.1-0`:

- upstream repository: https://gitsvn-nt.oru.se/iliad/software/iliad_execution.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/iliad_execution-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## iliad_executive

```
* initial
* Contributors: Marc Hanheide
```

## iliad_topological

```
* initial
* Contributors: Marc Hanheide
```
