### PR TITLE
genjava: 1.0.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -61,6 +61,11 @@ repositories:
       version: master
     status: developed
   genjava:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/genjava.git
+      version: 1.0.0-0
     source:
       type: git
       url: https://github.com/LCAS/genjava.git


### PR DESCRIPTION
Increasing version of package(s) in repository `genjava` to `1.0.0-0`:

- upstream repository: https://github.com/LCAS/genjava.git
- release repository: https://github.com/lcas-releases/genjava.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## genjava

```
* lcas version
* Merge pull request #15 <https://github.com/lcas/genjava/issues/15> from jubeira/gradle_3-5-1
  Gradle update: 3.5.1
* Using 'doLast' instead of '<<' operator in templates.
* Gradle update: 3.5.1
* Merge pull request #13 <https://github.com/lcas/genjava/issues/13> from meyerj/patch-1
  Fix non-existent dependency warning for the catkin API (fix #7 <https://github.com/lcas/genjava/issues/7>)
* Fix non-existent dependency warning for the catkin API (fix #7 <https://github.com/lcas/genjava/issues/7>)
* Contributors: Johannes Meyer, Juan Ignacio Ubeira, Julian Cerruti, Marc Hanheide
```
