### PR TITLE
coordination_oru_ros: 0.3.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -37,7 +37,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/iliad-project/coordination_oru-release.git
-      version: 0.3.0-0
+      version: 0.3.1-0
     source:
       type: git
       url: https://github.com/FedericoPecora/coordination_oru_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `coordination_oru_ros` to `0.3.1-0`:

- upstream repository: https://github.com/FedericoPecora/coordination_oru_ros.git
- release repository: https://github.com/iliad-project/coordination_oru-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.3.0-0`

## coordination_oru_msgs

- No changes

## coordination_oru_ros

```
* added missing dep
* Contributors: Marc Hanheide
```
