### PR TITLE
iliad_distribution: 0.0.7-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -78,11 +78,14 @@ repositories:
     release:
       packages:
       - iliad_distribution
+      - iliad_launch_manipulation
+      - iliad_launch_navigation
+      - iliad_launch_system
       - iliad_restricted
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/iliad_distribution.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://gitsvn-nt.oru.se/iliad/software/iliad_metapackage.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_distribution` to `0.0.7-0`:

- upstream repository: https://gitsvn-nt.oru.se/iliad/software/iliad_metapackage.git
- release repository: https://github.com/lcas-releases/iliad_distribution.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.0.6-0`

## iliad_distribution

```
* changelogs
* basic structure for packages with launch directories
* Contributors: Marc Hanheide
* basic structure for packages with launch directories
* Contributors: Marc Hanheide
```

## iliad_launch_manipulation

```
* bugfix about missing catkin dep
* added placeholders
* basic structure for packages with launch directories
* Contributors: Marc Hanheide
* bugfix about missing catkin dep
* added placeholders
* basic structure for packages with launch directories
* Contributors: Marc Hanheide
```

## iliad_launch_navigation

```
* bugfix about missing catkin dep
* added placeholders
* basic structure for packages with launch directories
* Contributors: Marc Hanheide
* bugfix about missing catkin dep
* added placeholders
* basic structure for packages with launch directories
* Contributors: Marc Hanheide
```

## iliad_launch_system

```
* bugfix about missing catkin dep
* added placeholders
* basic structure for packages with launch directories
* Contributors: Marc Hanheide
* bugfix about missing catkin dep
* added placeholders
* basic structure for packages with launch directories
* Contributors: Marc Hanheide
```

## iliad_restricted

```
* changelogs
* Contributors: Marc Hanheide
```
