### PR TITLE
iliad_smp: 0.1.4-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -133,7 +133,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/restricted-releases.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_smp` to `0.1.4-0`:

- upstream repository: https://gitsvn-nt.oru.se/palmieri/iliad_smp.git
- release repository: https://github.com/LCAS/restricted-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.1.3-0`

## iliad_smp_global_planner

```
* Considering also dynamic obstacles into the costmap2D
* adding example file to launch the iliad smp planner on the citi truck
* Contributors: Luigi Palmieri (Robert Bosch GmbH, CR/AER)
```
