### PR TITLE
perception_oru: 1.0.32-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -293,6 +293,22 @@ repositories:
       version: kinetic-devel
     status: maintained
   perception_oru:
+    release:
+      packages:
+      - graph_map
+      - ndt_fuser
+      - ndt_generic
+      - ndt_localization
+      - ndt_map
+      - ndt_offline
+      - ndt_registration
+      - ndt_rviz
+      - ndt_visualisation
+      - perception_oru
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://tzkr@gitsvn-nt.oru.se/iliad/software/perception_oru-iliad-release.git
+      version: 1.0.32-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru` to `1.0.32-0`:

- upstream repository: https://github.com/tstoyanov/perception_oru-private
- release repository: https://tzkr@gitsvn-nt.oru.se/iliad/software/perception_oru-iliad-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## graph_map

```
* Removed the old package.
* Added dense parameter.
* added imu undistortion in graph_offline_mapping2
* working on filter
* fixed names for mcl in graph_map
* performed calibration if imu-lidar
* automatic calibration finished with rough initial parameters
* added cost function
* changed path to bag file etc
* Added normalization on the keyframe dist on rotation.
* zero motion frames registration
* observation histogram to find closest map node added
* added narf
* improved registraiton
* added volxel grid
* added more maps and changed registration parameters slightly
* test arla submaps different bags
* preparing for test
* fixied observation based mapswitching
* added observation vector
* added observation location for maps
* improved testing and added multi-thread support
* improved evaluations, changed fuser implementation etc.
* added examples for online/offline ndt-d2d slam
* Changed namespace lslgeneric to perception_oru .moved all include files in pkg 'graph_map'  into subdirectory according to repository convention.
* changed motion model of graph_mcl
* Contributors: Chittaranjan Srinivas Swaminathan, Chittaranjan Swamminathan, Daniel Adolfsson, Henrik Andreasson, Jan Carstensen, Malcolm Mielle, Todor Stoyanov, Tomasz Kucner, Daniel Adolfsson
```

## ndt_fuser

```
* added deprecated warning to ndt_fuser
* ATTENTION all: PCL_DEFINITIONS and Cmake warning removed
  Solve the issue with Eigen using 16 and 32 bits alignment when
  forgetting to use PCL_DEFINITION which uses sse on some
  architecture with Eigen 3.3.
* Changed namespace lslgeneric to perception_oru .moved all include files in pkg 'graph_map'  into subdirectory according to repository convention.
* mapping and localization running for ncfm
* added file to open rosbag in ndt_offline
* ndt graph fuser offline
* Contributors: Chittaranjan Swamminathan, Daniel Adolfsson, Henrik Andreasson, Malcolm Mielle, Todor Stoyanov, Tomasz Kucner, Daniel Adolfsson
```

## ndt_generic

```
* More cleaning of ndt_generic package.
  Devel one viz pack
* Removed the old package.
* Contributors: Chittaranjan Srinivas Swaminathan, Chittaranjan Swamminathan, Daniel Adolfsson, Henrik Andreasson, Malcolm Mielle, Todor Stoyanov, Tomasz Kucner, Daniel Adolfsson
```

## ndt_localization

```
* Removed the old package.
* ported 3d localization
* Prior for 2D localisation with NDTH
* ndt_localization: documentation
* ndt_localization: using eigen container for vector
  Solve a memory alignment problem using Eigen, vectors and particules
* ndt_localization: motion and sensor model as param + methods
  THe sensor and motion model of the MCL are now parameters
  with default values like the old ones. Also added new methods:
  * Input the moved pointcloud
  * Input the unmoved Pointcloud with sensor pose.
  Malcolm
* ndt_loc: remove useless NDTMap + accesor to cellsize
* ndt_loc + ndt_map: do not remove horizontal cell
  in loc + check for gaussian in getclosestcell
  Do not remove floor and roof from the localization
  Also getClosestCell now work with NDT-OM maps.
  Malcolm
* Changed namespace lslgeneric to perception_oru .moved all include files in pkg 'graph_map'  into subdirectory according to repository convention.
* Localisation with laser and filter
* ndt_localization: removed all the legacy nodes
* MCL with pointcloud
* ndt_localization with velodyne
* Contributors: Chittaranjan Swamminathan, Daniel Adolfsson, Henrik Andreasson, Malcolm Mielle, Todor Stoyanov, Tomasz Kucner, Daniel Adolfsson
```

## ndt_map

- No changes

## ndt_offline

```
* ndt_offline: log file as parameters
* added examples for online/offline ndt-d2d slam
* changed lslgeneric to perception_oru
* fixed errors in ndt_offline
* ground truth offline
* Contributors: Chittaranjan Swamminathan, Daniel Adolfsson, Henrik Andreasson, Malcolm Mielle, Todor Stoyanov
```

## ndt_registration

```
* small fixes
* Contributors: Chittaranjan Srinivas Swaminathan, Daniel Adolfsson, Henrik Andreasson, Jan Carstensen, Malcolm Mielle, Todor Stoyanov, Tomasz Kucner
```

## ndt_rviz

```
* Successfully merged ndt_rviz and ndt_rviz_visualisation
* Contributors: Chittaranjan Swamminathan, Daniel Adolfsson, Henrik Andreasson, Malcolm Mielle, Todor Stoyanov, Tomasz Kucner
```

## ndt_visualisation

- No changes

## perception_oru

- No changes
