### PR TITLE
perception_oru: 1.0.33-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -293,6 +293,23 @@ repositories:
       version: kinetic-devel
     status: maintained
   perception_oru:
+    release:
+      packages:
+      - graph_localization
+      - graph_map
+      - ndt_fuser
+      - ndt_generic
+      - ndt_localization
+      - ndt_map
+      - ndt_offline
+      - ndt_registration
+      - ndt_rviz
+      - ndt_visualisation
+      - perception_oru
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://gitsvn-nt.oru.se/iliad/software/perception_oru-iliad-release.git
+      version: 1.0.33-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru` to `1.0.33-0`:

- upstream repository: https://github.com/tstoyanov/perception_oru-private
- release repository: https://gitsvn-nt.oru.se/iliad/software/perception_oru-iliad-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.4`
- previous version for package: `null`

## graph_localization

```
* Working version
* Contributors: Daniel Adolfsson
```
