### PR TITLE
thorvald: 0.0.6-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -759,6 +759,7 @@ repositories:
   thorvald:
     release:
       packages:
+      - thorvald
       - thorvald_2dnav
       - thorvald_base
       - thorvald_bringup
@@ -767,12 +768,13 @@ repositories:
       - thorvald_gui
       - thorvald_model
       - thorvald_msgs
+      - thorvald_simulator
       - thorvald_teleop
       - thorvald_twist_mux
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/thorvald-releases.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `0.0.6-0`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/LCAS/thorvald-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.4`
- previous version for package: `0.0.5-0`

## thorvald

```
* Merge pull request #36 <https://github.com/LCAS/Thorvald/issues/36> from gcielniak/kinetic-devel
  Metapackage added so that all packages can be installed in one go
* Additional metapackage for thorvald simulator.
  Other minor fixes:
  - thorvald_base depends now on thorvald_model
  - fixed model path in thorvald_base launch file
* Metapackage added so that all thorvald packages can be installed in one go: sudo apt-get install ros-kinetic-thorvald.
* Contributors: Grzegorz Cielniak, larsgrim
* Merge pull request #36 <https://github.com/LCAS/Thorvald/issues/36> from gcielniak/kinetic-devel
  Metapackage added so that all packages can be installed in one go
* Additional metapackage for thorvald simulator.
  Other minor fixes:
  - thorvald_base depends now on thorvald_model
  - fixed model path in thorvald_base launch file
* Metapackage added so that all thorvald packages can be installed in one go: sudo apt-get install ros-kinetic-thorvald.
* Contributors: Grzegorz Cielniak, larsgrim
```

## thorvald_2dnav

- No changes

## thorvald_base

```
* Merge pull request #36 <https://github.com/LCAS/Thorvald/issues/36> from gcielniak/kinetic-devel
  Metapackage added so that all packages can be installed in one go
* Additional metapackage for thorvald simulator.
  Other minor fixes:
  - thorvald_base depends now on thorvald_model
  - fixed model path in thorvald_base launch file
* Merge pull request #35 <https://github.com/LCAS/Thorvald/issues/35> from larsgrim/kinetic-devel
  Added support for 1wd1ws, fixed odometry bug and added CAN topics
* fixed odometry bug and added CAN topics
* added CANFrame msg
* added support for 1wd1ws robots
* Contributors: Grzegorz Cielniak, larsgrim
```

## thorvald_bringup

```
* Merge pull request #35 <https://github.com/LCAS/Thorvald/issues/35> from larsgrim/kinetic-devel
  Added support for 1wd1ws, fixed odometry bug and added CAN topics
* fixed odometry bug and added CAN topics
* added support for 1wd1ws robots
* Contributors: larsgrim
```

## thorvald_can_devices

```
* Merge pull request #35 <https://github.com/LCAS/Thorvald/issues/35> from larsgrim/kinetic-devel
  Added support for 1wd1ws, fixed odometry bug and added CAN topics
* fixed odometry bug and added CAN topics
* Contributors: larsgrim
```

## thorvald_gazebo_plugins

- No changes

## thorvald_gui

- No changes

## thorvald_model

```
* Merge pull request #35 <https://github.com/LCAS/Thorvald/issues/35> from larsgrim/kinetic-devel
  Added support for 1wd1ws, fixed odometry bug and added CAN topics
* fixed odometry bug and added CAN topics
* added support for 1wd1ws robots
* added passive wheels to xacro
* Contributors: larsgrim
```

## thorvald_msgs

- No changes

## thorvald_simulator

```
* Merge pull request #36 <https://github.com/LCAS/Thorvald/issues/36> from gcielniak/kinetic-devel
  Metapackage added so that all packages can be installed in one go
* Additional metapackage for thorvald simulator.
  Other minor fixes:
  - thorvald_base depends now on thorvald_model
  - fixed model path in thorvald_base launch file
* Contributors: Grzegorz Cielniak, larsgrim
* Merge pull request #36 <https://github.com/LCAS/Thorvald/issues/36> from gcielniak/kinetic-devel
  Metapackage added so that all packages can be installed in one go
* Additional metapackage for thorvald simulator.
  Other minor fixes:
  - thorvald_base depends now on thorvald_model
  - fixed model path in thorvald_base launch file
* Contributors: Grzegorz Cielniak, larsgrim
```

## thorvald_teleop

- No changes

## thorvald_twist_mux

- No changes
