### PR TITLE
perception_oru: 1.0.40-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -309,7 +309,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/perception_oru-iliad-release.git
-      version: 1.0.39-0
+      version: 1.0.40-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru` to `1.0.40-0`:

- upstream repository: https://github.com/tstoyanov/perception_oru-private
- release repository: https://gitsvn-nt.oru.se/iliad/software/perception_oru-iliad-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.39-0`

## graph_localization

- No changes

## graph_map

- No changes

## ndt_fuser

```
* updated ndt_fuser fix
* Contributors: Tomasz Kucner
```

## ndt_generic

- No changes

## ndt_localization

- No changes

## ndt_map

- No changes

## ndt_offline

- No changes

## ndt_registration

- No changes

## ndt_rviz

- No changes

## ndt_visualisation

- No changes

## perception_oru

- No changes
