### PR TITLE
perception_oru: 1.0.41-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -295,8 +295,6 @@ repositories:
   perception_oru:
     release:
       packages:
-      - graph_localization
-      - graph_map
       - ndt_fuser
       - ndt_generic
       - ndt_localization
@@ -309,7 +307,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/perception_oru-iliad-release.git
-      version: 1.0.40-0
+      version: 1.0.41-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_oru` to `1.0.41-0`:

- upstream repository: https://github.com/tstoyanov/perception_oru-private
- release repository: https://gitsvn-nt.oru.se/iliad/software/perception_oru-iliad-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.4`
- previous version for package: `1.0.40-0`

## ndt_fuser

- No changes

## ndt_generic

```
* Fixed >> vs > > problem.
* Contributors: Chittaranjan Srinivas Swaminathan, Chittaranjan Swamminathan, Henrik Andreasson, Malcolm Mielle, Tomasz Kucner, daniel, daniel adolfsson, mailto:dla.adolfsson@gmail.com
```

## ndt_localization

```
* merged with removal of MCL-NDT
* ported 3d localization
* Prior for 2D localisation with NDTH
* Contributors: Chittaranjan Swamminathan, Henrik Andreasson, Malcolm Mielle, Tomasz Kucner, daniel, daniel adolfsson, mailto:dla.adolfsson@gmail.com
```

## ndt_map

```
* removed graph_map
* changed initial map frame of lidar in online fuser to sensor pose, also working with graph registration
* Contributors: Henrik Andreasson, Tomasz Kucner, daniel, daniel adolfsson
```

## ndt_offline

```
* removed graph_map
* ndt_offline compiles some nodes are blacklisted to be resolved accordingly see issue #31 <https://github.com/tstoyanov/perception_oru-private/issues/31>
* Contributors: Chittaranjan Swamminathan, Henrik Andreasson, Malcolm Mielle, Tomasz Kucner, daniel, daniel adolfsson
```

## ndt_registration

- No changes

## ndt_rviz

```
* Successfully merged ndt_rviz and ndt_rviz_visualisation
* Contributors: Chittaranjan Swamminathan, Tomasz Kucner, daniel
```

## ndt_visualisation

- No changes

## perception_oru

```
* removed graph_map
* Contributors: Chittaranjan Swamminathan, Tomasz Kucner
```
