### PR TITLE
rasberry: 0.0.3-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -330,13 +330,16 @@ repositories:
     release:
       packages:
       - rasberry
+      - rasberry_actors
+      - rasberry_bringup
       - rasberry_des
       - rasberry_gazebo
+      - rasberry_move_base
       - rasberry_navigation
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/rasberry.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rasberry` to `0.0.3-0`:

- upstream repository: https://github.com/LCAS/RASberry.git
- release repository: https://github.com/lcas-releases/rasberry.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.0.2-0`

## rasberry

- No changes

## rasberry_actors

```
* Fixed rasberry_actors/maps reference
* Seperated the gazebo world with polytunnels and actor spawning into seperate packages (rasberry_gazebo and actor_gazebo, respectively).
  There is also a rasberry_bringup package that launches everything together
* Contributors: adambinch
* Fixed rasberry_actors/maps reference
* Seperated the gazebo world with polytunnels and actor spawning into seperate packages (rasberry_gazebo and actor_gazebo, respectively).
  There is also a rasberry_bringup package that launches everything together
* Contributors: adambinch
```

## rasberry_bringup

```
* equal versions
* Can specify starting pose in rasberry_bringup/launch/rasberry_simulation.launch
* should work now ...
* Seperated the gazebo world with polytunnels and actor spawning into seperate packages (rasberry_gazebo and actor_gazebo, respectively).
  There is also a rasberry_bringup package that launches everything together
* Contributors: Marc Hanheide, adambinch
* equal versions
* Can specify starting pose in rasberry_bringup/launch/rasberry_simulation.launch
* should work now ...
* Seperated the gazebo world with polytunnels and actor spawning into seperate packages (rasberry_gazebo and actor_gazebo, respectively).
  There is also a rasberry_bringup package that launches everything together
* Contributors: Marc Hanheide, adambinch
```

## rasberry_des

- No changes

## rasberry_gazebo

```
* Added more Local Planners -> check description
  *EBand Local Planner
  -Launch file: "move_base_eband.launch"
  -Parameters under directory "rasberry_move_base/config/eband/"
  *Teb Local Planner
  -Launch file: "move_base_teb.launch"
  -Parameters under directory "rasberry_move_base/config/teb/"
  *DWA Local Planner
  -Launch file: "move_base_dwa.launch"
  -Parameters under directory "rasberry_move_base/config/dwa/"
* Seperated the gazebo world with polytunnels and actor spawning into seperate packages (rasberry_gazebo and actor_gazebo, respectively).
  There is also a rasberry_bringup package that launches everything together
* Merge branch 'master' of https://github.com/jailander/RASberry
  # Conflicts:
  #     rasberry_gazebo/package.xml
* removing unnecessary stuff
* rasberry_move_base config files
* Merge branch 'master' of https://github.com/adambinch/RASberry
* Merge branch 'master' of https://github.com/adambinch/RASberry
* Added a new launch file 'gazebo_single_AB.launch'.
  This provides a switch to turn actors on or off and also launches
  the teleop_xbox nodes so that Thorvald can be controlled with the
  xbox controller. Note that actors are now specified in another
  new launch file 'include_actors.launch'
* adding rasberry_move_base_package
* gazebo dependency removed from cmakelists and package.xml
* Merge branch 'master' of https://github.com/adambinch/RASberry
* All packages found in cmakelists are now included in package.xml
* Merge branch 'master' of https://github.com/adambinch/RASberry
  # Conflicts:
  #     rasberry_gazebo/package.xml
* More changes for testing ...
* Merge branch 'master' of https://github.com/adambinch/RASberry
* Merge branch 'master' of https://github.com/LCAS/RASberry
  # Conflicts:
  #     rasberry_gazebo/launch/gazebo_single.launch
* Some changes for Jaime to check.
* The type 2 actor's laser scanner is now included in the tf tree.
  The launch file 'thorvald_world_AB.launch' now launches the Thorvald robot model into the gazebo world.
  The README.md has been adjusted to reflect these changes.
* making enclosure world default environment for now
* adding world and navigation maps
* Contributors: Jaime Pulido Fentanes, Johnmenex, adambinch
```

## rasberry_move_base

```
* equal versions
* adding robot pose publisher to move_base launch file
* Removing unused files
* Added more Local Planners -> check description
  *EBand Local Planner
  -Launch file: "move_base_eband.launch"
  -Parameters under directory "rasberry_move_base/config/eband/"
  *Teb Local Planner
  -Launch file: "move_base_teb.launch"
  -Parameters under directory "rasberry_move_base/config/teb/"
  *DWA Local Planner
  -Launch file: "move_base_dwa.launch"
  -Parameters under directory "rasberry_move_base/config/dwa/"
* latest move _base configs
* rasberry_move_base config files
* adding rasberry_move_base_package
* Contributors: Jaime Pulido Fentanes, Johnmenex, Marc Hanheide
* equal versions
* adding robot pose publisher to move_base launch file
* Removing unused files
* Added more Local Planners -> check description
  *EBand Local Planner
  -Launch file: "move_base_eband.launch"
  -Parameters under directory "rasberry_move_base/config/eband/"
  *Teb Local Planner
  -Launch file: "move_base_teb.launch"
  -Parameters under directory "rasberry_move_base/config/teb/"
  *DWA Local Planner
  -Launch file: "move_base_dwa.launch"
  -Parameters under directory "rasberry_move_base/config/dwa/"
* latest move _base configs
* rasberry_move_base config files
* adding rasberry_move_base_package
* Contributors: Jaime Pulido Fentanes, Johnmenex, Marc Hanheide
```

## rasberry_navigation

- No changes
