### PR TITLE
thorvald: 0.1.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -782,7 +782,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/thorvald-releases.git
-      version: 0.0.6-0
+      version: 0.1.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `0.1.0-0`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/LCAS/thorvald-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.0.6-0`

## thorvald

```
* 0.0.7
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_2dnav

```
* 0.0.7
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_base

```
* 0.0.7
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_bringup

```
* 0.0.7
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_can_devices

```
* 0.0.7
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_gazebo_plugins

```
* 0.0.7
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_gui

```
* 0.0.7
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_model

```
* 0.0.7
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_msgs

```
* 0.0.7
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_simulator

```
* 0.0.7
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_teleop

```
* 0.0.7
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_twist_mux

```
* 0.0.7
* changelogs
* Contributors: Marc Hanheide
```
