### PR TITLE
velodyne_simulator8: 1.0.7-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -862,6 +862,15 @@ repositories:
       version: master
     status: maintained
   velodyne_simulator8:
+    release:
+      packages:
+      - velodyne_description
+      - velodyne_gazebo_plugins
+      - velodyne_simulator
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/velodyne_simulator.git
+      version: 1.0.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator8` to `1.0.7-0`:

- upstream repository: https://github.com/LCAS/velodyne_simulator.git
- release repository: https://github.com/lcas-releases/velodyne_simulator.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## velodyne_description

```
* Added GPU support
* Updated inertia tensors for VLP-16 and HDL-32E to realistic values
* Removed unnecessary file extraction code in cmake
* Contributors: Kevin Hallenbeck, Max Schwarz
```

## velodyne_gazebo_plugins

```
* Added GPU support
* Added support for Gazebo 9
* Improved behavior of max range calculation
* Removed trailing slashes in robot namespace
* Fixed resolution of 1 not supported
* Fixed issue with only 1 vert or horiz ray
* Fixed cmake exports and warning
* Contributors: Kevin Hallenbeck, Jacob Seibert, Naoki Mizuno
```

## velodyne_simulator

- No changes
