### PR TITLE
velodyne_simulator8: 1.1.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -862,6 +862,15 @@ repositories:
       version: master
     status: maintained
   velodyne_simulator8:
+    release:
+      packages:
+      - velodyne_description8
+      - velodyne_gazebo_plugins8
+      - velodyne_simulator8
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/velodyne_simulator.git
+      version: 1.1.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator8` to `1.1.0-0`:

- upstream repository: https://github.com/LCAS/velodyne_simulator.git
- release repository: https://github.com/lcas-releases/velodyne_simulator.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
