### PR TITLE
velodyne_simulator8: 1.1.1-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -870,7 +870,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/velodyne_simulator.git
-      version: 1.1.0-0
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator8` to `1.1.1-1`:

- upstream repository: https://github.com/LCAS/velodyne_simulator.git
- release repository: https://github.com/lcas-releases/velodyne_simulator.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `1.1.0-0`

## velodyne_description8

```
* Merge branch 'gazebo8' of https://github.com/LCAS/velodyne_simulator into gazebo8
* Contributors: mailto:mfernandezcarmona@lincoln.ac.uk
```

## velodyne_gazebo_plugins8

```
* removed gazebo8_ros from CMakelists
* Merge branch 'gazebo8' of https://github.com/LCAS/velodyne_simulator into gazebo8
* corrected dependency to point to gazebo8
* Contributors: mailto:mfernandezcarmona@lincoln.ac.uk
```

## velodyne_simulator8

```
* Merge branch 'gazebo8' of https://github.com/LCAS/velodyne_simulator into gazebo8
* Contributors: mailto:mfernandezcarmona@lincoln.ac.uk
```
