### PR TITLE
strands_navigation: 1.0.6-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -657,7 +657,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `1.0.6-0`:

- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.5-0`

## emergency_behaviours

- No changes

## joy_map_saver

- No changes

## message_store_map_switcher

```
* new c++11 (#359 <https://github.com/strands-project/strands_navigation/issues/359>)
* Contributors: Marc Hanheide
```

## monitored_navigation

- No changes

## nav_goals_generator

- No changes

## pose_initialiser

- No changes

## strands_navigation

- No changes

## strands_navigation_msgs

- No changes

## topological_logging_manager

- No changes

## topological_navigation

```
* Merge pull request #358 <https://github.com/strands-project/strands_navigation/issues/358> from Jailander/rasberry-devel
  re-adding ability to work with other planners
* Fixes bug on service call for adding node
* re-adding ability to work with other planners
* Revert "Revert "Revert "Adding the ability to work with local planners other than DWA"""
  This reverts commit b0ea99543615e6dfc8dbb2cb9969ce1da6ae546c.
* Revert "Fixing bug on add node service marker"
  This reverts commit 0a364cbfda27ea5971eeb871e286cfd186ceca1c.
* Revert "Revert "Adding the ability to work with local planners other than DWA""
  This reverts commit e11a93bf79b01e17889eb3e00750b8f588385f93.
* Revert "Adding the ability to work with local planners other than DWA"
  This reverts commit b86ca393944362eb9c0cf21884810f5c0f8862e2.
* Fixing bug on add node service marker
* Adding the ability to work with local planners other than DWA
* Contributors: Jaime Pulido Fentanes
```

## topological_rviz_tools

- No changes

## topological_utils

- No changes
