### PR TITLE
rosduct: 0.0.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -359,17 +359,22 @@ repositories:
       url: https://github.com/lcas/robot_blockly.git
       version: master
     status: developed
-  rosduct:
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/LCAS/rosduct.git
-      version: master
-    status: developed
   ros_web_apis:
     source:
       type: git
       url: https://github.com/LCAS/ros_web_apis.git
+      version: master
+    status: developed
+  rosduct:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/rosduct.git
+      version: 0.0.1-0
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/LCAS/rosduct.git
       version: master
     status: developed
   sandbox:


### PR DESCRIPTION
Increasing version of package(s) in repository `rosduct` to `0.0.1-0`:

- upstream repository: https://github.com/LCAS/rosduct.git
- release repository: https://github.com/lcas-releases/rosduct.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## rosduct

```
* adopted for release
* Extending README with docker use case
* Add note about rosout
* Add support for remapping, a way for dealing with multiple robots
* Add support for services
* Cleanup docs and add test for params
* Added efficient management of rosbridge subscribers
* Update client, latest version supports general introspection calls and param handling
* optimize publication
* Fixes to make it work, damn closures
* Initial commit
* Contributors: Marc Hanheide, Sammy Pfeiffer
```
