### PR TITLE
thorvald: 0.1.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -794,7 +794,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/thorvald-releases.git
-      version: 0.1.0-1
+      version: 0.1.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `0.1.1-0`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/LCAS/thorvald-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.1.0-1`

## thorvald

- No changes

## thorvald_2dnav

```
* Merge branch 'kinetic-devel' of github.com:LCAS/Thorvald into kinetic-devel
* Dependency fixes:
  Some dependency fixes thorvald_2dnav, thorvald_base and thorvlad_model
* Contributors: gpdas
```

## thorvald_base

```
* Merge branch 'kinetic-devel' of github.com:LCAS/Thorvald into kinetic-devel
* Dependency fixes:
  Some dependency fixes thorvald_2dnav, thorvald_base and thorvlad_model
* Contributors: gpdas
```

## thorvald_bringup

- No changes

## thorvald_can_devices

- No changes

## thorvald_gazebo_plugins

- No changes

## thorvald_gui

- No changes

## thorvald_model

```
* Merge branch 'kinetic-devel' of github.com:LCAS/Thorvald into kinetic-devel
* Dependency fixes:
  Some dependency fixes thorvald_2dnav, thorvald_base and thorvlad_model
* Contributors: gpdas
```

## thorvald_msgs

- No changes

## thorvald_simulator

- No changes

## thorvald_teleop

- No changes

## thorvald_twist_mux

- No changes
