### PR TITLE
rasberry: 0.0.4-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -339,7 +339,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/rasberry.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rasberry` to `0.0.4-0`:

- upstream repository: https://github.com/LCAS/RASberry.git
- release repository: https://github.com/lcas-releases/rasberry.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.0.3-0`

## rasberry

- No changes

## rasberry_actors

```
* removed depend to gazebo_ros
* Added simulation with velodyne and kinect2, rviz config file to visualize them and changed actor to use gpu based simulated laser
* Contributors: Marc Hanheide, mailto:mfernandezcarmona@lincoln.ac.uk
```

## rasberry_bringup

```
* Added simulation with velodyne and kinect2, rviz config file to visualize them and changed actor to use gpu based simulated laser
* Changing topological map name
* adding simulation start-up script
* Contributors: Jaime Pulido Fentanes, mailto:mfernandezcarmona@lincoln.ac.uk
```

## rasberry_des

```
* Minor correction in polytunnel_des_config.yaml
* Adding white noise to introduce variations in picking and transportation rates
  Gaussian white noise is added to Picker's picking rate and transportation rate, and Robot's transportation rate. The noise is assumed to have zero mean and 2% of picking (or transportation) rate.
* Contributors: gpdas
```

## rasberry_gazebo

```
* removed depend to gazebo_ros
* use gazebo 8
  closes #65 <https://github.com/lcas/rasberry/issues/65>
* Added simulation with velodyne and kinect2, rviz config file to visualize them and changed actor to use gpu based simulated laser
* Merge branch 'master' of github.com:LCAS/RASberry
* Changing topological map name
* adding simulation start-up script
* Merge branch 'master' of github.com:LCAS/RASberry
  conflict resolved in rasberry_gazebo/worlds/thorvald_AB.world
* World file changes because of polytunnel definition interchange in models_AB.yaml
* Contributors: Jaime Pulido Fentanes, Marc Hanheide, gpdas, mailto:mfernandezcarmona@lincoln.ac.uk
```

## rasberry_move_base

- No changes

## rasberry_navigation

- No changes
