### PR TITLE
depth_sensors: 0.0.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -44,6 +44,18 @@ repositories:
       version: master
     status: developed
   depth_sensors:
+    release:
+      packages:
+      - depth_sensors
+      - kinect2_description
+      - kinect_control
+      - kinect_description
+      - senz3d_description
+      - simple_description
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/depth_sensors.git
+      version: 0.0.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depth_sensors` to `0.0.1-0`:

- upstream repository: https://github.com/LCAS/depth_sensors.git
- release repository: https://github.com/lcas-releases/depth_sensors.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## depth_sensors

```
* Maintainer updated
* simple camera model for pose-to-pixel-space projection debugging
* moved Kinect V2 control into its own package
* moved Kinect V2 description into its own package
* moved Senz3d description into its own package
* metapackage for depth sensors
* Contributors: lude-ma, mailto:mfernandezcarmona@lincoln.ac.uk
```

## kinect2_description

```
* former kinect2_description now as part of a bigger one
* Contributors: mailto:mfernandezcarmona@lincoln.ac.uk
```

## kinect_control

```
* Maintainer updated
* moved Kinect V2 control into its own package
* Contributors: lude-ma, mailto:mfernandezcarmona@lincoln.ac.uk
```

## kinect_description

```
* mirroring Kinect V2 topic names (kinect2_iai ros package)
* kinect launch file moved from baxter_data_acquisition
* fixed xacro missing namespace (depreciation warning)
* fixed floating kinect stand model
* moved Kinect V2 description into its own package
* Contributors: lude-ma
```

## senz3d_description

```
* Maintainer updated
* moved Senz3d description into its own package
* Contributors: lude-ma, mailto:mfernandezcarmona@lincoln.ac.uk
```

## simple_description

```
* Maintainer updated
* extended simple camera model with depth sensor
* simple camera model for pose-to-pixel-space projection debugging
* Contributors: lude-ma, mailto:mfernandezcarmona@lincoln.ac.uk
```
