### PR TITLE
iai_kinect2: 0.0.2-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -100,6 +100,18 @@ repositories:
       version: master
     status: developed
   iai_kinect2:
+    release:
+      packages:
+      - iai_kinect2
+      - kinect2_bridge
+      - kinect2_calibration
+      - kinect2_registration
+      - kinect2_viewer
+      - libfreenect2_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/iai_kinect2.git
+      version: 0.0.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iai_kinect2` to `0.0.2-0`:

- upstream repository: https://github.com/LCAS/iai_kinect2.git
- release repository: https://github.com/lcas-releases/iai_kinect2.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`
