### PR TITLE
iai_kinect2: 0.0.5-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -111,7 +111,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/iai_kinect2.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iai_kinect2` to `0.0.5-0`:

- upstream repository: https://github.com/LCAS/iai_kinect2.git
- release repository: https://github.com/lcas-releases/iai_kinect2.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.0.4-0`
