### PR TITLE
iai_kinect2: 0.0.8-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -110,7 +110,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/iai_kinect2.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iai_kinect2` to `0.0.8-0`:

- upstream repository: https://github.com/LCAS/iai_kinect2.git
- release repository: https://github.com/lcas-releases/iai_kinect2.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.7-0`

## iai_kinect2

- No changes

## kinect2_bridge

```
* Libfreenect2 dev (#2 <https://github.com/LCAS/iai_kinect2/issues/2>)
  * Changed freenect2 from submodule to subproject with git. catkin_make_isolated --install works
  * m.ch.
  * added git as a dependence and install targets
  * w.i.p.
  * Update CMakeLists.txt
  * freenect2 moved to its own fork
  * Works in my docker...
* Contributors: Manuel Fernandez-Carmona
```

## kinect2_calibration

- No changes

## kinect2_registration

- No changes

## kinect2_viewer

- No changes
