### PR TITLE
thorvald: 0.2.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -844,7 +844,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/thorvald-releases.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `0.2.1-0`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/LCAS/thorvald-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.2.0-0`

## thorvald

- No changes

## thorvald_2dnav

- No changes

## thorvald_base

```
* added leading slash to joint names
* Contributors: larsgrim
```

## thorvald_bringup

```
* added leading slash to joint names
* Contributors: larsgrim
```

## thorvald_can_devices

- No changes

## thorvald_gazebo_plugins

- No changes

## thorvald_gui

- No changes

## thorvald_model

```
* Fixes in thorval_model for multi-thorvald simulation
  Changes in thrvald_model.xacro and sensor_modules_lincoln.xacro
  - corrected the indentation
  - arg tf_prefix doesn't need a trailing "/"
  - added missing tf_prefix for links
  - added missing namespace for topics
* Merge pull request #41 <https://github.com/LCAS/Thorvald/issues/41> from LCAS/velodyne-kinect2-thorvald
  Added xacro file that includes Kinect 2 and Velodyne 16
* Merge branch 'kinetic-devel' into velodyne-kinect2-thorvald
* Velodyne simulation provided by gazeb8-compatible package from LCAS
* Added rough xacro file including kinect2 and velodyne
* Contributors: Manuel Fernandez-Carmona, Marc Hanheide, gpdas, mailto:mfernandezcarmona@lincoln.ac.uk
```

## thorvald_msgs

- No changes

## thorvald_simulator

- No changes

## thorvald_teleop

- No changes

## thorvald_twist_mux

- No changes
