### PR TITLE
strands_hri: 0.2.2-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -670,7 +670,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_hri.git
-      version: 0.2.0-0
+      version: 0.2.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_hri` to `0.2.2-0`:

- upstream repository: https://github.com/strands-project/strands_hri.git
- release repository: https://github.com/strands-project-releases/strands_hri.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `0.2.0-0`

## han_action_dispatcher

```
* changelogs
* Contributors: Marc Hanheide
```

## hrsi_launch

```
* changelogs
* Contributors: Marc Hanheide
```

## hrsi_representation

```
* changelogs
* Contributors: Marc Hanheide
```

## hrsi_state_prediction

```
* changelogs
* Contributors: Marc Hanheide
```

## hrsi_velocity_costmaps

```
* changelogs
* Contributors: Marc Hanheide
```

## strands_gazing

```
* changelogs
* Contributors: Marc Hanheide
```

## strands_hri

```
* changelogs
* Contributors: Marc Hanheide
```

## strands_hri_launch

```
* changelogs
* Contributors: Marc Hanheide
```

## strands_human_aware_navigation

```
* changelogs
* Contributors: Marc Hanheide
```

## strands_human_following

```
* changelogs
* Contributors: Marc Hanheide
```

## strands_interaction_behaviours

```
* changelogs
* Contributors: Marc Hanheide
```

## strands_simple_follow_me

```
* changelogs
* Contributors: Marc Hanheide
```

## strands_visualise_speech

```
* changelogs
* Contributors: Marc Hanheide
```
