### PR TITLE
strands_ui: 0.1.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -805,7 +805,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_ui.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_ui` to `0.1.1-0`:

- upstream repository: https://github.com/strands-project/strands_ui.git
- release repository: https://github.com/strands-project-releases/strands_ui.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.1.0-0`

## mary_tts

```
* Merge pull request #107 <https://github.com/strands-project/strands_ui/issues/107> from strands-project/sync_reply
  resolved sync issue with clearing queue
* resolved sync issue with clearing queue
* Contributors: Lindsey User, Marc Hanheide
```

## mongodb_media_server

- No changes

## music_player

- No changes

## pygame_managed_player

- No changes

## robot_talk

- No changes

## sound_player_server

- No changes

## strands_ui

- No changes

## strands_webserver

```
* Updated email to new Oxford address
* Contributors: Nick Hawes
```
