### PR TITLE
rosduct: 0.0.2-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -427,7 +427,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/rosduct.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosduct` to `0.0.2-0`:

- upstream repository: https://github.com/LCAS/rosduct.git
- release repository: https://github.com/lcas-releases/rosduct.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.1-0`

## rosduct

```
* latch remote topics
* latch remote topics
* Contributors: Marc Hanheide
```
