### PR TITLE
depth_sensors: 0.0.3-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -63,7 +63,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/depth_sensors.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `depth_sensors` to `0.0.3-0`:

- upstream repository: https://github.com/LCAS/depth_sensors.git
- release repository: https://github.com/lcas-releases/depth_sensors.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.2-0`

## asus_description

```
* Update CMakeLists.txt
  removed mesh directory from install. Asus mesh is taken from turtlebot_description package
* Contributors: Manuel Fernandez-Carmona
```

## depth_sensors

- No changes

## kinect2_description

- No changes

## kinect_control

- No changes

## kinect_description

- No changes

## senz3d_description

- No changes

## simple_description

- No changes
