### PR TITLE
ndt_core: 2.0.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -291,6 +291,18 @@ repositories:
       version: kinetic-devel
     status: developed
   ndt_core:
+    release:
+      packages:
+      - ndt_core
+      - ndt_generic
+      - ndt_map
+      - ndt_registration
+      - ndt_rviz
+      - ndt_visualisation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://gitsvn-nt.oru.se/iliad/software/releases/ndt_core-release.git
+      version: 2.0.0-0
     source:
       type: git
       url: https://gitsvn-nt.oru.se/software/ndt_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ndt_core` to `2.0.0-0`:

- upstream repository: https://gitsvn-nt.oru.se/software/ndt_core.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/ndt_core-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## ndt_core

```
* fixed tags in package.xml
* copying core packages from perception_oru to ndt_core
* Contributors: Tomasz Kucner
```

## ndt_generic

```
* packages
* add compilation only on dev success
* add compilation only on dev success
* pushing pose queue
* removed bug which allocated twice as much memory
* changed sensor offset
* Updated HX motion model. Commented out the old model acessing method.
* Fixed motion_model variable assignment bug.
* working on polar ndt
* copying core packages from perception_oru to ndt_core
* Contributors: Henrik Andreasson, Tomasz Kucner, daniel
```

## ndt_map

```
* packages
* pushing pose queue
* removed bug which allocated twice as much memory
* working on polar ndt
* added ring segmentation polar
* updated polar map
* working on polar ndt
* added polar ndt
* Update ndt_map.h with l2 norm function
* Update ndt_map.cpp with l2 norm function
* copying core packages from perception_oru to ndt_core
* Contributors: Daniel Adolfsson, Tomasz Kucner, daniel, daniel adolfsson
```

## ndt_registration

```
* packages
* added overlap
* copying core packages from perception_oru to ndt_core
* Contributors: Tomasz Kucner, daniel
```

## ndt_rviz

```
* packages
* removed ros output
* Sorted eigen values of covariance matrices by size to ensure correct visuaslization, erlier the rotation was off occasionally
* copying core packages from perception_oru to ndt_core
* Contributors: Tomasz Kucner, daniel, daniel adolfsson
```

## ndt_visualisation

```
* packages
* copying core packages from perception_oru to ndt_core
* Contributors: Tomasz Kucner
```
