### PR TITLE
ndt_tools: 2.0.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -309,6 +309,17 @@ repositories:
       version: master
     status: developed
   ndt_tools:
+    release:
+      packages:
+      - ndt_feature_finder
+      - ndt_fuser
+      - ndt_localization
+      - ndt_offline
+      - ndt_tools
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://gitsvn-nt.oru.se/iliad/software/releases/ndt_tools-release.git
+      version: 2.0.0-0
     source:
       type: git
       url: https://gitsvn-nt.oru.se/software/ndt_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ndt_tools` to `2.0.0-0`:

- upstream repository: https://gitsvn-nt.oru.se/software/ndt_tools.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/ndt_tools-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## ndt_feature_finder

```
* Intiial commit
* Contributors: Tomasz Kucner
```

## ndt_fuser

```
* Intiial commit
* Contributors: Tomasz Kucner
```

## ndt_localization

```
* Intiial commit
* Contributors: Tomasz Kucner
```

## ndt_offline

```
* Merge branch 'master' of gitsvn-nt.oru.se:software/ndt_tools
* removed ndt_calibration
* Intiial commit
* Contributors: Tomasz Kucner, daniel
```

## ndt_tools

```
* Merge branch 'master' of gitsvn-nt.oru.se:software/ndt_tools
* backup
* Update package.xml
* Intiial commit
* Contributors: Tomasz Kucner
```
