### PR TITLE
graph_map: 2.0.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -102,6 +102,16 @@ repositories:
       version: kinetic
     status: maintained
   graph_map:
+    release:
+      packages:
+      - graph_localization
+      - graph_map
+      - ndt_calibration
+      - ndt_evaluation
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://gitsvn-nt.oru.se/iliad/software/releases/graph_map-release.git
+      version: 2.0.0-0
     source:
       type: git
       url: https://gitsvn-nt.oru.se/iliad/software/graph_map.git


### PR DESCRIPTION
Increasing version of package(s) in repository `graph_map` to `2.0.0-0`:

- upstream repository: https://gitsvn-nt.oru.se/iliad/software/graph_map.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/graph_map-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## graph_localization

```
* updated changelogs
* Contributors: Daniel Adolfsson, Henrik Andreasson, daniel, daniel adolfsson, mailto:dla.adolfsson@gmail.com, sunliamm
```

## graph_map

```
* updated changelogs
* Contributors: Daniel Adolfsson, Henrik Andreasson, daniel, daniel adolfsson, mailto:dla.adolfsson@gmail.com, sunliamm
```

## ndt_calibration

```
* updated changelogs
* Contributors: Daniel Adolfsson, Henrik Andreasson, daniel, daniel adolfsson, mailto:dla.adolfsson@gmail.com, sunliamm
```

## ndt_evaluation

```
* updated changelogs
* Contributors: Daniel Adolfsson, Henrik Andreasson, daniel, daniel adolfsson, mailto:dla.adolfsson@gmail.com, sunliamm
```
