### PR TITLE
iliad_distribution: 0.0.8-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -146,7 +146,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/iliad_distribution.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_distribution` to `0.0.8-0`:

- upstream repository: https://gitsvn-nt.oru.se/iliad/software/iliad_metapackage.git
- release repository: https://github.com/lcas-releases/iliad_distribution.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.7-0`

## iliad_distribution

```
* removed unnecessary ones and added graph_localisation
* Contributors: Marc Hanheide
```

## iliad_launch_manipulation

```
* removed unnecessary ones and added graph_localisation
* Contributors: Marc Hanheide
```

## iliad_launch_navigation

```
* removed unnecessary ones and added graph_localisation
* Contributors: Marc Hanheide
```

## iliad_launch_system

```
* removed unnecessary ones and added graph_localisation
* Contributors: Marc Hanheide
```

## iliad_restricted

- No changes
