### PR TITLE
cliff_map: 0.0.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -30,6 +30,13 @@ repositories:
       version: master
     status: developed
   cliff_map:
+    release:
+      packages:
+      - cliffmap_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
+      version: 0.0.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cliff_map` to `0.0.1-0`:

- upstream repository: https://github.com/ksatyaki/cliffmap_ros.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## cliffmap_ros

```
* Add LGPLv3
* ROS service is ready.
* Add grid map organize function + variables
* Functions to interpret the map as a gridmap.
* Contributors: Chittaranjan Srinivas Swaminathan
```
