### PR TITLE
coordination_oru_ros: 0.5.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -51,7 +51,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/iliad-project/coordination_oru-release.git
-      version: 0.4.0-1
+      version: 0.5.0-0
     source:
       type: git
       url: https://github.com/FedericoPecora/coordination_oru_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `coordination_oru_ros` to `0.5.0-0`:

- upstream repository: https://github.com/FedericoPecora/coordination_oru_ros.git
- release repository: https://github.com/iliad-project/coordination_oru-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.4.0-1`

## coordination_oru_msgs

- No changes

## coordination_oru_ros

```
* post demo
* Arena demo done
* New cycle 3 and reverse service implemented in tracker
* Added remote launch files and modified truncating service
* Added arena launch files; now depends on coordination_oru v. 0.3.2
* Bumped up version of coordination_oru to 0.3.1
* Point and click remote launch.
* Fixed remapping of topics...
* Added service to abort mission
* Adding ability to interrupt mission (incomplete); now estimates vel and dist from RobotReport message
* Using refactored mission stack management in coordination_oru (new release 0.2.0)
* Compute tasks sequentially in marshalling lane example
* Now depends on new coordination_oru release (0.1.9)
* Added new launch files
* Added deadlock elimination with prioritized motion planning
* Added launch file for smp planner
* Fixed two trucks in robot lab launch file
* Added preliminary version of RobotLab coord demo
* Added multiple trucks launch file in robot_lab
* Contributors: Federico Pecora, Henrik Andreasson
```
