### PR TITLE
rosduct: 0.0.4-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -465,7 +465,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/rosduct.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosduct` to `0.0.4-0`:

- upstream repository: https://github.com/LCAS/rosduct.git
- release repository: https://github.com/lcas-releases/rosduct.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.3-0`

## rosduct

```
* Merge pull request #2 <https://github.com/LCAS/rosduct/issues/2> from MFernandezCarmona/master
  Update package.xml
* reintroduced pydispatcher
* remove pydispatch
  the problem is we need pip install pydispatcher, not pydispatch . So for now we remove this dependency until we have a deb package for this python package
* Caching Service exceptions...
* Update conversions.py
* Update package.xml
  These should solve the following errors I had runing rosduct:
  ImportError: No module named ws4py.client.threadedclient
  ImportError: No module named pydispatch
* Contributors: Manuel Fernandez-Carmona, Marc Hanheide
```
