### PR TITLE
bayes_tracking: 1.1.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -22,7 +22,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/bayestracking.git
-      version: 1.0.8-0
+      version: 1.1.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bayes_tracking` to `1.1.0-0`:

- upstream repository: https://github.com/LCAS/bayestracking.git
- release repository: https://github.com/lcas-releases/bayestracking.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.8-0`

## bayes_tracking

```
* support for Polar Models (#22 <https://github.com/LCAS/bayestracking/issues/22>)
  * Added 2D Polar Observation Model
  * no default parameter values in redeclared functions
  * proper building
  * Changes for backward-compatibility
  * Backward-compatibility of example code
* Fixed condition logic that caused label checks to always be used (#21 <https://github.com/LCAS/bayestracking/issues/21>)
* Update snapcraft.yaml
* Update snapcraft.yaml
* Update snapcraft.yaml
* Contributors: Marc Hanheide, SeanTasker, Strands JENKINS Daemon
```
