### PR TITLE
strands_perception_people: 1.6.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -792,7 +792,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 1.6.0-0
+      version: 1.6.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `1.6.0-1`:

- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.6.0-0`

## bayes_people_tracker

```
* changed from cdondrup to marc
* Contributors: Marc Hanheide
```

## bayes_people_tracker_logging

```
* changed from cdondrup to marc
* Contributors: Marc Hanheide
```

## detector_msg_to_pose_array

```
* changed from cdondrup to marc
* Contributors: Marc Hanheide
```

## ground_plane_estimation

```
* changed from cdondrup to marc
* Contributors: Marc Hanheide
```

## human_trajectory

- No changes

## mdl_people_tracker

```
* changed from cdondrup to marc
* Contributors: Marc Hanheide
```

## odometry_to_motion_matrix

```
* changed from cdondrup to marc
* Contributors: Marc Hanheide
```

## people_tracker_emulator

```
* changed from cdondrup to marc
* Contributors: Marc Hanheide
```

## people_tracker_filter

```
* changed from cdondrup to marc
* Contributors: Marc Hanheide
```

## perception_people_launch

```
* changed from cdondrup to marc
* Contributors: Marc Hanheide
```

## rwth_upper_body_skeleton_random_walk

- No changes

## strands_perception_people

```
* changed from cdondrup to marc
* removed warco and head-orientation
* removed wheelchair_detector for kinetic
* Contributors: Marc Hanheide
```

## upper_body_detector

```
* changed from cdondrup to marc
* Contributors: Marc Hanheide
```

## vision_people_logging

- No changes

## visual_odometry

```
* changed from cdondrup to marc
* Contributors: Marc Hanheide
```
