### PR TITLE
strands_perception_people: 1.7.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -792,7 +792,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 1.6.0-0
+      version: 1.7.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `1.7.0-0`:

- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.6.0-0`

## bayes_people_tracker

```
* Adapting to changes in bayestracking (#220 <https://github.com/strands-project/strands_perception_people/issues/220>)
  * Adapted to scosar/bayestracking with 2D Polar Model and Added option to select Particle Filter
  * random fixes
  * Adapted to backward-compatibility changes of bayestracking
* Namespaces and topics specified as parameters. (#218 <https://github.com/strands-project/strands_perception_people/issues/218>)
  * Merged with ENRICHME branch. Parametrized topics/frame_ids
  * Undone the timestamp change
  Hi,
  It was a careless change. I originally thought that the timestamp should reflect time creation of the data, but it also makes sense the way you made it plus it's better not to change the meaning of a field now.
  * Reverted changes on original config.
  * Update detector.h
  * Default initialization on constructor
  * Update KConnectedComponentLabeler.cpp
  * Update KConnectedComponentLabeler.cpp
  * Update detector.cpp
  * Suggested change in data interpretation.
  Still pending to check that 0 corresponds to NaN in ushort
  * Bug corrected.
  * commented duplicate code
* Contributors: Manuel Fernandez-Carmona, scosar
```

## bayes_people_tracker_logging

- No changes

## detector_msg_to_pose_array

- No changes

## ground_plane_estimation

```
* Namespaces and topics specified as parameters. (#218 <https://github.com/strands-project/strands_perception_people/issues/218>)
  * Merged with ENRICHME branch. Parametrized topics/frame_ids
  * Undone the timestamp change
  Hi,
  It was a careless change. I originally thought that the timestamp should reflect time creation of the data, but it also makes sense the way you made it plus it's better not to change the meaning of a field now.
  * Reverted changes on original config.
  * Update detector.h
  * Default initialization on constructor
  * Update KConnectedComponentLabeler.cpp
  * Update KConnectedComponentLabeler.cpp
  * Update detector.cpp
  * Suggested change in data interpretation.
  Still pending to check that 0 corresponds to NaN in ushort
  * Bug corrected.
  * commented duplicate code
* Contributors: Manuel Fernandez-Carmona
```

## human_trajectory

- No changes

## mdl_people_tracker

- No changes

## odometry_to_motion_matrix

- No changes

## people_tracker_emulator

```
* Updated email to new Oxford address
* Contributors: Nick Hawes
```

## people_tracker_filter

```
* Namespaces and topics specified as parameters. (#218 <https://github.com/strands-project/strands_perception_people/issues/218>)
  * Merged with ENRICHME branch. Parametrized topics/frame_ids
  * Undone the timestamp change
  Hi,
  It was a careless change. I originally thought that the timestamp should reflect time creation of the data, but it also makes sense the way you made it plus it's better not to change the meaning of a field now.
  * Reverted changes on original config.
  * Update detector.h
  * Default initialization on constructor
  * Update KConnectedComponentLabeler.cpp
  * Update KConnectedComponentLabeler.cpp
  * Update detector.cpp
  * Suggested change in data interpretation.
  Still pending to check that 0 corresponds to NaN in ushort
  * Bug corrected.
  * commented duplicate code
* Contributors: Manuel Fernandez-Carmona
```

## perception_people_launch

- No changes

## rwth_upper_body_skeleton_random_walk

- No changes

## strands_perception_people

- No changes

## upper_body_detector

```
* Update package.xml
* Add FAQ about UBD time-sync to README
* Namespaces and topics specified as parameters. (#218 <https://github.com/strands-project/strands_perception_people/issues/218>)
  * Merged with ENRICHME branch. Parametrized topics/frame_ids
  * Undone the timestamp change
  Hi,
  It was a careless change. I originally thought that the timestamp should reflect time creation of the data, but it also makes sense the way you made it plus it's better not to change the meaning of a field now.
  * Reverted changes on original config.
  * Update detector.h
  * Default initialization on constructor
  * Update KConnectedComponentLabeler.cpp
  * Update KConnectedComponentLabeler.cpp
  * Update detector.cpp
  * Suggested change in data interpretation.
  Still pending to check that 0 corresponds to NaN in ushort
  * Bug corrected.
  * commented duplicate code
* Contributors: Lucas Beyer, Manuel Fernandez-Carmona, Marc Hanheide
```

## vision_people_logging

- No changes

## visual_odometry

- No changes
