### PR TITLE
executive_smach_strands: 3.0.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -78,6 +78,16 @@ repositories:
       version: master
     status: maintained
   executive_smach_strands:
+    release:
+      packages:
+      - executive_smach
+      - smach
+      - smach_msgs
+      - smach_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/executive_smach.git
+      version: 3.0.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach_strands` to `3.0.0-0`:

- upstream repository: https://github.com/strands-project/executive_smach.git
- release repository: https://github.com/strands-project-releases/executive_smach.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## executive_smach

```
* changed maintainer for local version
* Merge pull request #5 <https://github.com/strands-project/executive_smach/issues/5> from ros/indigo-devel
  Import upstream
* 2.0.1
* changelog 2.0.1
* Merge pull request #48 <https://github.com/strands-project/executive_smach/issues/48> from 130s/i/update_ci4
  [indigo-devel] Sync to master branch. Update CI conf to enable ROS IJKL
* [package.xml] Update maintainer.
* packaging: switching to format 2
* Contributors: Isaac I.Y. Saito, Jonathan Bohren, Marc Hanheide, Nick Hawes
```

## smach

```
* changed maintainer for local version
* Merge pull request #5 <https://github.com/strands-project/executive_smach/issues/5> from ros/indigo-devel
  Import upstream
* Merge pull request #59 <https://github.com/strands-project/executive_smach/issues/59> from josephcoombe/patch-2
  Update state.py Docstrings' @type descriptions
* Update state.py
  Change array -> list
  Change string -> str
* Merge pull request #56 <https://github.com/strands-project/executive_smach/issues/56> from cclauss/remove-set_shutdown_cb
  Typo set_shutdown_cb() --> set_shutdown_check()
* Typo set_shutdown_cb() --> set_shutdown_check()
* 2.0.1
* changelog 2.0.1
* Merge pull request #48 <https://github.com/strands-project/executive_smach/issues/48> from 130s/i/update_ci4
  [indigo-devel] Sync to master branch. Update CI conf to enable ROS IJKL
* [package.xml] Update maintainer.
* Contributors: Isaac I.Y. Saito, Joseph Coombe, Marc Hanheide, Nick Hawes, cclauss
```

## smach_msgs

```
* changed maintainer for local version
* Merge pull request #5 <https://github.com/strands-project/executive_smach/issues/5> from ros/indigo-devel
  Import upstream
* 2.0.1
* changelog 2.0.1
* Merge pull request #48 <https://github.com/strands-project/executive_smach/issues/48> from 130s/i/update_ci4
  [indigo-devel] Sync to master branch. Update CI conf to enable ROS IJKL
* [package.xml] Update maintainer.
* packaging: switching to format 2
* Contributors: Isaac I.Y. Saito, Jonathan Bohren, Marc Hanheide, Nick Hawes
```

## smach_ros

```
* changed maintainer for local version
* Merge pull request #5 <https://github.com/strands-project/executive_smach/issues/5> from ros/indigo-devel
  Import upstream
* 2.0.1
* changelog 2.0.1
* Merge pull request #48 <https://github.com/strands-project/executive_smach/issues/48> from 130s/i/update_ci4
  [indigo-devel] Sync to master branch. Update CI conf to enable ROS IJKL
* [test] More pep8 enforced.
* [package.xml] Update maintainer.
* make rostest in CMakeLists optional (ros/rosdistro#3010 <https://github.com/ros/rosdistro/issues/3010>)
* change MonitorState and document its behavior
* increment n_checks only *after* checking
  otherwise, setting max_checks=1 results in a MonitorState that returns the 'valid' outcome for any message
* Specify queue sizes for introspection publishers
* tests: adding test for actionlib timeout
* packaging: switching to format 2
* Using correct timeout
* SimpleActionState will no longer wait forever
  for a missing ActionServer
* Contributors: Isaac I.Y. Saito, Jonathan Bohren, Loy, Lukas Bulwahn, Marc Hanheide, Nick Hawes, Nils Berg, contradict
```
