### PR TITLE
strands_social: 0.0.16-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -840,6 +840,19 @@ repositories:
       version: hydro-devel
     status: developed
   strands_social:
+    release:
+      packages:
+      - card_image_tweet
+      - datamatrix_read
+      - fake_camera_effects
+      - image_branding
+      - social_card_reader
+      - strands_social
+      - strands_tweets
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_social.git
+      version: 0.0.16-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_social` to `0.0.16-0`:

- upstream repository: https://github.com/strands-project/strands_social.git
- release repository: https://github.com/strands-project-releases/strands_social.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## card_image_tweet

- No changes

## datamatrix_read

- No changes

## fake_camera_effects

- No changes

## image_branding

```
* added missing install targets
* Contributors: Jailander
```

## social_card_reader

```
* Merge pull request #47 <https://github.com/strands-project/strands_social/issues/47> from gestom/hydro-devel
  Social card reader parameters reconfigurable.
* Social card reader parameters reconfigurable.
* Contributors: Marc Hanheide, Tom Krajnik
```

## strands_social

- No changes

## strands_tweets

- No changes
