### PR TITLE
strands_social: 0.1.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -843,7 +843,6 @@ repositories:
     release:
       packages:
       - card_image_tweet
-      - datamatrix_read
       - fake_camera_effects
       - image_branding
       - social_card_reader
@@ -852,7 +851,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_social.git
-      version: 0.0.16-0
+      version: 0.1.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_social` to `0.1.0-0`:

- upstream repository: https://github.com/strands-project/strands_social.git
- release repository: https://github.com/strands-project-releases/strands_social.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.16-0`

## card_image_tweet

- No changes

## fake_camera_effects

- No changes

## image_branding

- No changes

## social_card_reader

- No changes

## strands_social

```
* Merge pull request #51 <https://github.com/strands-project/strands_social/issues/51> from Jailander/hydro-devel
  Removing datamatrix read package
* removing deprecated dependency
* Contributors: Jaime Pulido Fentanes, Marc Hanheide
```

## strands_tweets

- No changes
