### PR TITLE
pcl_detector: 0.0.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -408,6 +408,13 @@ repositories:
       version: master
     status: developed
   pcl_detector:
+    release:
+      packages:
+      - object3d_detector
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/pcl_detector.git
+      version: 0.0.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_detector` to `0.0.1-0`:

- upstream repository: https://github.com/LCAS/pcl_detector.git
- release repository: https://github.com/lcas-releases/pcl_detector.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.2`
- previous version for package: `null`

## object3d_detector

```
* extracted from original repo
* Initial commit
* Contributors: Marc Hanheide
```
