### PR TITLE
thorvald: 0.2.2-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -926,7 +926,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/thorvald-releases.git
-      version: 0.2.1-0
+      version: 0.2.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `0.2.2-0`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/LCAS/thorvald-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.2.1-0`

## thorvald

```
* cleanup in package.xml
* Contributors: larsgrim
```

## thorvald_2dnav

```
* added argument in localization_local.launch to kill publication of tf transform
* holonomic robot
* cleanup in package.xml
* added license
* removed dep on razor imu
* Cleaned up thorvald_2dnav and created more sensible launch files
* Changed from using positions to velocities for odom and added slash to tf prefix
* removed 'greenhouse' costmap layer
* Contributors: adambinch, larsgrim
```

## thorvald_base

```
* odom tf params and defaults in base_link now like found in other ros controllers
* base_driver can now broadcast odmetry frame as parent or child of base_link
* removed some files that had snuck in
* added tf broadcaster
* cleanup in package.xml
* added license
* Merge branch 'kinetic-devel' of https://github.com/LCAS/Thorvald
* enclosure board ros services are now in node name space
* disabled battery communication
* dev and port no longer hard coded
* Contributors: larsgrim
```

## thorvald_bringup

```
* odom tf params and defaults in base_link now like found in other ros controllers
* base_driver can now broadcast odmetry frame as parent or child of base_link
* removed joy arg
* cleanup in package.xml
* Launch files for example configurations now include thorvald_example.launch, not thorvald_bringup.launch
* added license
* New example launch file for use as template
* Now only brings up base and model. Args are without default or default is empty string
* default model_extra is now empty
* Made gazebo optional. Default is true.
* made include of ekf_localization optional. Default is false. Deleted unused launch file
* Contributors: larsgrim
```

## thorvald_can_devices

```
* cleanup in package.xml
* added license
* Contributors: larsgrim
```

## thorvald_gazebo_plugins

```
* cleanup in package.xml
* added license
* Contributors: larsgrim
```

## thorvald_gui

```
* drive status now in gui
* added topomap to gui
* added 3D moded to default_gui
* cleanup in package.xml
* added license
* Contributors: larsgrim
```

## thorvald_model

```
* base_driver can now broadcast odmetry frame as parent or child of base_link
* cleanup in package.xml
* Added slash after tf prefix
* added license
* Updated prefix part of frames and joints
* default value for model_extra is now empty string
* removed unused launch files
* Contributors: larsgrim
```

## thorvald_msgs

```
* cleanup in package.xml
* added license
* Contributors: larsgrim
```

## thorvald_simulator

```
* cleanup in package.xml
* Contributors: larsgrim
```

## thorvald_teleop

```
* base_driver can now broadcast odmetry frame as parent or child of base_link
* removed misplaced slash in teleop_xbox.launch
* remapped homing service, Y+A to home steering
* cleanup in package.xml
* No more teleop_joy namespace
* Increased min turning radius in xbox config
* added license
* New teleop launch file without default values for args
* Contributors: larsgrim, thorvald007
```

## thorvald_twist_mux

```
* cleanup in package.xml
* added license
* Contributors: larsgrim
```
