### PR TITLE
mongodb_store: 0.4.2-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -317,7 +317,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.3.5-0
+      version: 0.4.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.4.2-1`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.3.5-0`

## libmongocxx_ros

```
* instead of lsb-release read /etc/os-version from CMake to find OS version
* Contributors: Ferenc Balint-Benczedi
```

## mongodb_log

```
* instead of lsb-release read /etc/os-version from CMake to find OS version
* Contributors: Ferenc Balint-Benczedi
```

## mongodb_store

```
* instead of lsb-release read /etc/os-version from CMake to find OS version
* Contributors: Ferenc Balint-Benczedi
```

## mongodb_store_msgs

- No changes
