### PR TITLE
slackeros: 0.0.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -590,6 +590,11 @@ repositories:
       version: master
     status: maintained
   slackeros:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/slackeros.git
+      version: 0.0.1-0
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `slackeros` to `0.0.1-0`:

- upstream repository: https://github.com/marc-hanheide/slackeros.git
- release repository: https://github.com/lcas-releases/slackeros.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## slackeros

```
* more bugfixes
* deps
* deps
* use argparse
* with params
* rostopics
* tidy
* dynamic typing support
* support for Empty Service
* first working version
* init
* Initial commit
* Contributors: Marc Hanheide
```
