### PR TITLE
slackeros: 0.0.1-2 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -594,7 +594,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/slackeros.git
-      version: 0.0.1-0
+      version: 0.0.1-2
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `slackeros` to `0.0.1-2`:

- upstream repository: https://github.com/marc-hanheide/slackeros.git
- release repository: https://github.com/lcas-releases/slackeros.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.1-0`

## slackeros

```
* more bugfixes
* deps
* deps
* use argparse
* with params
* rostopics
* tidy
* dynamic typing support
* support for Empty Service
* first working version
* init
* Initial commit
* Contributors: Marc Hanheide
```
