### PR TITLE
slackeros: 0.0.3-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -594,7 +594,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/slackeros.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `slackeros` to `0.0.3-0`:

- upstream repository: https://github.com/marc-hanheide/slackeros.git
- release repository: https://github.com/lcas-releases/slackeros.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.2-0`

## slackeros

```
* fixes #3 <https://github.com/marc-hanheide/slackeros/issues/3>
* fix #1 <https://github.com/marc-hanheide/slackeros/issues/1> and #2 <https://github.com/marc-hanheide/slackeros/issues/2>
* robust eception handling
* fixed launch install
* Contributors: Marc Hanheide
```
