### PR TITLE
cliff_map: 0.0.2-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -36,7 +36,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
-      version: 0.0.2-0
+      version: 0.0.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cliff_map` to `0.0.2-1`:

- upstream repository: https://github.com/ksatyaki/cliffmap_ros.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.2-0`

## cliffmap_ros

```
* Add missing target
* Add header to msg
```
