### PR TITLE
lidar_object_detection: 0.0.2-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -294,6 +294,11 @@ repositories:
       version: master
     status: maintained
   lidar_object_detection:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/lidar_object_detection_release.git
+      version: 0.0.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lidar_object_detection` to `0.0.2-0`:

- upstream repository: https://github.com/LCAS/lidar_object_detection_release.git
- release repository: https://github.com/lcas-releases/lidar_object_detection_release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## lidar_object_detection

```
* add tf_conversions
* added nav_msgs dep
* more fixed
* attempt to better install and fix build problems
* changed to use cv_bridge
* fix two bugs in the cloud normailization
* update intensity model
* remove third parties
* ready to release
* Initial commit
* Contributors: Kevin Li Sun, Marc Hanheide, kevin
```
