### PR TITLE
persistent_topics: 1.5.2-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -459,6 +459,11 @@ repositories:
       version: kinetic-devel
     status: maintained
   persistent_topics:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/persistent_topics.git
+      version: 1.5.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `persistent_topics` to `1.5.2-0`:

- upstream repository: https://github.com/marc-hanheide/persistent_topics.git
- release repository: https://github.com/lcas-releases/persistent_topics.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## persistent_topics

- No changes
