### PR TITLE
libfreenect2: 0.0.9-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -286,7 +286,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/libfreenect2.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `libfreenect2` to `0.0.9-0`:

- upstream repository: https://github.com/LCAS/libfreenect2.git
- release repository: https://github.com/lcas-releases/libfreenect2.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.0.8-0`

## libfreenect2

```
* Merge pull request #1 <https://github.com/LCAS/libfreenect2/issues/1> from LCAS/cuda9.0
  changed dependency to cuda 9.0
* changed dependency to cuda 9.0
* Contributors: Marc Hanheide, mailto:mfernandezcarmona@lincoln.ac.uk
```
