### PR TITLE
rgbd_gpu_detector: 2.0.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -497,6 +497,13 @@ repositories:
       version: master
     status: developed
   rgbd_gpu_detector:
+    release:
+      packages:
+      - rgbd_gpu_person_detector
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://gitsvn-nt.oru.se/iliad/software/releases/rgbd_gpu_detector.git
+      version: 2.0.1-0
     source:
       type: git
       url: https://gitsvn-nt.oru.se/linder/rgbd_gpu_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_gpu_detector` to `2.0.1-0`:

- upstream repository: https://gitsvn-nt.oru.se/linder/rgbd_gpu_detector.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/rgbd_gpu_detector.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## rgbd_gpu_person_detector

```
* Remove Python setup
* Configure CUDA 9.0 and CUDNN dependencies for buildfarm
* Adding dependency to cuda_latest
* Initial commit
* Updated CMakeLists for build farm
* Removing unused files
* Move weights file into .ros for buildfarm deployment
* Update README
* Contributors: Timm Linder
```
