### PR TITLE
uol_cmp9767m: 0.0.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1039,6 +1039,13 @@ repositories:
       version: master
     status: maintained
   uol_cmp9767m:
+    release:
+      packages:
+      - uol_cmp9767m_base
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/CMP9767M.git
+      version: 0.0.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uol_cmp9767m` to `0.0.1-0`:

- upstream repository: https://github.com/LCAS/CMP9767M.git
- release repository: https://github.com/lcas-releases/CMP9767M.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## uol_cmp9767m_base

```
* fixed cmake
* added stub package
* Contributors: Marc Hanheide
```
