### PR TITLE
iliad_human_perception: 1.0.2-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -199,7 +199,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception_release.git
-      version: 1.0.1-2
+      version: 1.0.2-0
     source:
       type: git
       url: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_human_perception` to `1.0.2-0`:

- upstream repository: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception_release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.0.1-2`

## iliad_human_perception_launch

```
* Saving Rviz config
* Saving current version for ILIAD
* Solved bug
* Fix to odom_to_tf script
* Adding odom_to_tf script. Bugfixes to playback launch file.
* Saving progress on refactoring of tracking pipeline, namespace changes, improved bagfile postprocessing
* Saving progress on launch files
* Launch file structure set up, now need to be filled with contents
* Restructuring launch files. Moved central startup file to iliad_metapackage.
* Updating playback files for Cititruck at NCFM
* Adding script for creating thumbnails from bags
* Adding uncommitted script for poses from NDT-MCL to TF
* Pushing uncommitted changes to bagfile postprocessing script
* Update README, package.xml, CMakeLists.txt
* Kinect v2 and Asus point cloud generation from bagfiles works
* Working on RefleX integration
* Remove bt_truck suffix from postprocess_bagfiles script
* Saving progress, bagfile postprocessing script + playback launch file
* Remove unused arg
* Remove remappings from launch files, now done by bagfile postprocessing script
* Adding launch files from SPENCER
* Initial script for remapping topics and TF frames in recorded bagfiles
* Saving progress, working on playback script and remapping of topics from recorded bagfiles
* Refactoring launch file structure, work in progress. Adding playback scripts for bagfiles. Removing multi-master stuff.
* Removed zeroconf file (is not working). README explains how to automatically add ip to bashrc
* added zeroconf option
* corrected typo
* Adding launch files from SPENCER
* Added parameter for multicast group and readme file with configuration
* Bugfix
* Merge branch 'cherry-pick-16a7f453' into 'master'
  1.0.1
  See merge request !2
* 1.0.1
* Merge branch 'cherry-pick-86a85319' into 'master'
  added changelog
  See merge request !1
* added changelog
* Small modifications to launch files
* Added ROS multimaster to human perception
* Relaying of detector/tracker output topics
* README instructions updated
* First version of people detection and tracking in 2D laser, still requires fix to srl_laser_segmentation and srl_laser_detectors ROS interface
* Fix previous commit, somehow rospy.Rate() causes latency
* Limit publish rate of groundtruth tracked persons to 30 Hz (was 1000 Hz)
* Bugfixes
* Restructuring launch files; script to publish groundtruth tracks from Gazebo
* Initial version of iliad_human_perception_launch, untested
* Contributors: Manuel Fernandez-Carmona, Marc Hanheide, Timm Linder, mailto:mfernandezcarmona@lincoln.ac.uk
```
