### PR TITLE
iliad_human_perception: 1.0.6-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -199,7 +199,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception_release.git
-      version: 1.0.5-0
+      version: 1.0.6-0
     source:
       type: git
       url: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_human_perception` to `1.0.6-0`:

- upstream repository: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception_release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.0.5-0`

## iliad_human_perception_launch

```
* Use high-precision model
* Integrate new version of Kevin's Velodyne detector
* Contributors: Timm Linder
```
