### PR TITLE
iliad_smp: 0.1.6-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -219,7 +219,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/restricted-releases.git
-      version: 0.1.5-1
+      version: 0.1.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_smp` to `0.1.6-0`:

- upstream repository: https://gitsvn-nt.oru.se/palmieri/iliad_smp.git
- release repository: https://github.com/LCAS/restricted-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `0.1.5-1`

## iliad_smp_global_planner

```
* Bug fix, setting type for the BicycleStateSpace
* Contributors: Luigi Palmieri (Robert Bosch GmbH, CR/AER)
```
