### PR TITLE
bayes_tracking: 1.2.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -22,7 +22,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/bayestracking.git
-      version: 1.1.0-0
+      version: 1.2.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bayes_tracking` to `1.2.0-0`:

- upstream repository: https://github.com/LCAS/bayestracking.git
- release repository: https://github.com/lcas-releases/bayestracking.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.1.0-0`

## bayes_tracking

```
* Flexible id associations (#23 <https://github.com/LCAS/bayestracking/issues/23>)
  * fix to use local headers first
  * proper support for tagged tracking
  * added tags tracking example
  * fix bug to only assign if not named yet
* Contributors: Marc Hanheide
```
