### PR TITLE
strands_morse: 0.2.3-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -801,7 +801,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.2.3-0`:

- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.2.2-0`

## strands_morse

```
* Merge pull request #175 <https://github.com/strands-project/strands_morse/issues/175> from francescodelduchetto/kinetic-devel
  the collection museum simulation
* simulation scaled according to real-world measures
* better lights for simulation
* the collection museum simulation
* Contributors: Marc Hanheide, francescodelduchetto
```
