### PR TITLE
strands_perception_people: 1.8.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -873,7 +873,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 1.7.0-0
+      version: 1.8.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `1.8.0-0`:

- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.7.0-0`

## bayes_people_tracker

```
* WIP: working towards tag-aware tracking (#221 <https://github.com/strands-project/strands_perception_people/issues/221>)
  * WIP
  * WIP
  * wip
  * good testing node
  * WIP
  * Fixed count
  * WIP
  * more documentation and testing
  * colors for variances
  * added rviz config
  * prune_named added
  * legacy param support
* Contributors: Marc Hanheide
```

## bayes_people_tracker_logging

- No changes

## detector_msg_to_pose_array

- No changes

## ground_plane_estimation

- No changes

## human_trajectory

- No changes

## mdl_people_tracker

- No changes

## odometry_to_motion_matrix

- No changes

## people_tracker_emulator

- No changes

## people_tracker_filter

- No changes

## perception_people_launch

- No changes

## rwth_upper_body_skeleton_random_walk

- No changes

## strands_perception_people

- No changes

## upper_body_detector

- No changes

## vision_people_logging

- No changes

## visual_odometry

- No changes
