### PR TITLE
rosduct: 0.0.5-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -533,7 +533,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/rosduct.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosduct` to `0.0.5-0`:

- upstream repository: https://github.com/LCAS/rosduct.git
- release repository: https://github.com/lcas-releases/rosduct.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.0.4-0`

## rosduct

```
* removed cuplicate dep
* removed cuplicate dep
* removed cuplicate dep
* Merge branch 'cwbollinger-master'
* Merge branch 'master' of https://github.com/cwbollinger/rosduct into cwbollinger-master
* Added services to remove topic/service from bridge
* Added services to dynamically expose topic/service
* Commented out over-verbose logging
* Exit rosduct when connection is broken.
  Can't seem to recover afterwards, so might as well exit
* Experiments to enable reconnections
* Contributors: Chris Bollinger, Marc Hanheide, christopheriksen
```
