### PR TITLE
uol_cmp9767m: 0.0.4-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1045,7 +1045,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/CMP9767M.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uol_cmp9767m` to `0.0.4-0`:

- upstream repository: https://github.com/LCAS/CMP9767M.git
- release repository: https://github.com/lcas-releases/CMP9767M.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.0.3-0`

## uol_cmp9767m_base

```
* Merge pull request #5 <https://github.com/LCAS/CMP9767M/issues/5> from gpdas/master
  Updated ground textures
* Cleanup
* Merge branch 'master' of github.com:LCAS/CMP9767M
* New ground textures and enclosure are added
  
  Fixed missing install targets in CMakeLists
  
  World file updated with models with new textures
  
  New wider robot configuration within the package
  
  Hokuyo laser ray visibility in gazebo is disabled
* Contributors: Marc Hanheide, gpdas
```
