### PR TITLE
velodyne_simulator8: 1.1.5-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1085,7 +1085,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/velodyne_simulator.git
-      version: 1.1.4-1
+      version: 1.1.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_simulator8` to `1.1.5-1`:

- upstream repository: https://github.com/LCAS/velodyne_simulator.git
- release repository: https://github.com/lcas-releases/velodyne_simulator.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.1.4-1`

## velodyne_description8

```
* Merge pull request #4 <https://github.com/LCAS/velodyne_simulator/issues/4> from gpdas/gazebo8
  some file still linked to velodyne_description instead of *8
* Some file links to velodyne_description replaced with corresponding ones in velodyne_description8
* Contributors: Marc Hanheide, gpdas
```

## velodyne_gazebo_plugins8

- No changes

## velodyne_simulator8

- No changes
