### PR TITLE
rosduct: 0.0.6-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -533,7 +533,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/rosduct.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosduct` to `0.0.6-0`:

- upstream repository: https://github.com/LCAS/rosduct.git
- release repository: https://github.com/lcas-releases/rosduct.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.0.5-0`

## rosduct

```
* Fix: ROSDuctConnection() object's latch attribute not set (#5 <https://github.com/LCAS/rosduct/issues/5>)
  * Fix for missing latch for local and remote topics - in ROSDuctConnection objects
  Setting the default value of msg.latch for local and remote topics to False
  If the latch value is given in the config (takes up to 4 values for topics), that value is taken
  * msg.latch takes string or bool values for local and remote topics
  Fix in check_if_msgs_are_installed() when local_topics remote_topics has 4 fields
* Contributors: Gautham P Das
```
