### PR TITLE
strands_ui: 0.2.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -936,7 +936,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_ui.git
-      version: 0.1.1-0
+      version: 0.2.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_ui` to `0.2.0-0`:

- upstream repository: https://github.com/strands-project/strands_ui.git
- release repository: https://github.com/strands-project-releases/strands_ui.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.1.1-0`

## mary_tts

```
* Merge pull request #108 <https://github.com/strands-project/strands_ui/issues/108> from francescodelduchetto/pull-req
  Catch cancel_goal of the action and stop the player accordingly.
* goal preemption stops marytts speaking
* Contributors: Marc Hanheide, francescodelduchetto
```

## mongodb_media_server

- No changes

## music_player

- No changes

## pygame_managed_player

- No changes

## robot_talk

- No changes

## sound_player_server

- No changes

## strands_ui

- No changes

## strands_webserver

- No changes
