### PR TITLE
catkin_simple: 0.2.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -30,6 +30,11 @@ repositories:
       version: master
     status: developed
   catkin_simple:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/catkin_simple.git
+      version: 0.2.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `catkin_simple` to `0.2.0-0`:

- upstream repository: https://github.com/LCAS/catkin_simple.git
- release repository: https://github.com/lcas-releases/catkin_simple.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## catkin_simple

```
* Merge pull request #27 <https://github.com/catkin/catkin_simple/issues/27> from flaviofontana/patch-1
  add dynamic reconfigure info to the readme
* add dynamic reconfigure info to the readme
* Merge pull request #26 <https://github.com/catkin/catkin_simple/issues/26> from flaviofontana/add_dynamic_reconfigure
  added autodetection of dynamic_reconfigure
* fixed indentation
* adding build dependency on gencfg
* adding all cfg all files at once
* added autodetection of dynamic_reconfigure
* Merge pull request #25 <https://github.com/catkin/catkin_simple/issues/25> from simonlynen/patch-1
  Fix typo
* Update catkin_simple-extras.cmake.em
* only install Media, not media, automatically
* [style] remove trailing whitespace
* Merge branch 'feature/install_roslaunch_files' of https://github.com/ethz-asl/catkin_simple into ethz-asl-feature/install_roslaunch_files
* Add informative cs_install() cmake output.
* cs_install() installs shared content folders
  * launch, rviz, urdf, meshes, maps, worlds, media and param
* Added automatic installation of roslaunch files with cs_install() macro if a launch folder exists in the source directory
* Merge pull request #22 <https://github.com/catkin/catkin_simple/issues/22> from ethz-asl/fix/install-include
  Fixed a bug in the install target for include directories
* Merge pull request #2 <https://github.com/catkin/catkin_simple/issues/2> from ethz-asl/fix/install-include
  Fix/install include
* Fixed a bug in the install target for include directories
* Merge pull request #1 <https://github.com/catkin/catkin_simple/issues/1> from catkin/master
  Pulling in changes from catkin
* Contributors: Flavio Fontana, Paul Furgale, Simon Lynen, Ulrich Schwesinger, William Woodall
```
