### PR TITLE
pcl_catkin_c11: 1.8.2-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -439,6 +439,11 @@ repositories:
       version: master
     status: developed
   pcl_catkin_c11:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/pcl_catkin.git
+      version: 1.8.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_catkin_c11` to `1.8.2-0`:

- upstream repository: https://github.com/LCAS/pcl_catkin.git
- release repository: https://github.com/lcas-releases/pcl_catkin.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## pcl_catkin_c11

- No changes
