### PR TITLE
pcl_catkin_c11: 1.8.3-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -443,7 +443,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/pcl_catkin.git
-      version: 1.8.2-0
+      version: 1.8.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_catkin_c11` to `1.8.3-0`:

- upstream repository: https://github.com/LCAS/pcl_catkin.git
- release repository: https://github.com/lcas-releases/pcl_catkin.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `1.8.2-0`

## pcl_catkin_c11

```
* Merge pull request #1 <https://github.com/LCAS/pcl_catkin/issues/1> from LCAS/submodule
  attempt to build as subdir
* attempt to build as subdir
* Contributors: Marc Hanheide, root
```
