### PR TITLE
pcl_conversions_c11: 0.2.2-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -450,6 +450,13 @@ repositories:
       url: https://github.com/LCAS/pcl_catkin.git
       version: lcas_c11
     status: maintained
+  pcl_conversions_c11:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/pcl_conversions.git
+      version: 0.2.2-0
+    status: maintained
   pcl_detector:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_conversions_c11` to `0.2.2-0`:

- upstream repository: https://github.com/LCAS/pcl_conversions.git
- release repository: https://github.com/lcas-releases/pcl_conversions.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## pcl_conversions_c11

```
* renaming
* renaming
* changed name and maintainer
* Merge pull request #1 <https://github.com/LCAS/pcl_conversions/issues/1> from ethz-asl/feature/switch_to_pcl_catkin
  switched from PCL to pcl_catkin dependency
* switched from PCL to pcl_catkin dependency
* Merge pull request #22 <https://github.com/LCAS/pcl_conversions/issues/22> from ros-perception/paulbovbel-patch-1
  Remove duplicated line
* Remove duplicated line
* Contributors: Marc Hanheide, Marko Panjek, Paul Bovbel, root
```
