### PR TITLE
perception_pcl_c11: 1.4.5-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -489,6 +489,16 @@ repositories:
       url: https://github.com/lcas/people_detection.git
       version: kinetic-devel
     status: maintained
+  perception_pcl_c11:
+    release:
+      packages:
+      - pcl_ros_c11
+      - perception_pcl_c11
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/perception_pcl_c11.git
+      version: 1.4.5-0
+    status: maintained
   persistent_topics:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `perception_pcl_c11` to `1.4.5-0`:

- upstream repository: https://github.com/LCAS/perception_pcl.git
- release repository: https://github.com/lcas-releases/perception_pcl_c11.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.6`
- previous version for package: `null`

## pcl_ros_c11

```
* rpath
* more renaming of libs
* renaming
* changed name and maintainer
* Merge pull request #1 <https://github.com/LCAS/perception_pcl/issues/1> from ethz-asl/feature/switch_to_pcl_catkin
  switched from PCL to pcl_catkin dependency
* switched from PCL to pcl_catkin dependency
* Contributors: Marc Hanheide, Marko Panjek, root
```

## perception_pcl_c11

```
* changed name and maintainer
* Contributors: Marc Hanheide
```
