### PR TITLE
pcl_conversions_c11: 0.2.3-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -455,7 +455,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/pcl_conversions.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     status: maintained
   pcl_detector:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_conversions_c11` to `0.2.3-0`:

- upstream repository: https://github.com/LCAS/pcl_conversions.git
- release repository: https://github.com/lcas-releases/pcl_conversions.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.2.2-0`

## pcl_conversions_c11

```
* Update package.xml
* Contributors: Marc Hanheide
```
