### PR TITLE
marvelmind_nav_lcas: 1.0.9-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -332,6 +332,13 @@ repositories:
       version: master
     status: developed
   marvelmind_nav_lcas:
+    release:
+      packages:
+      - marvelmind_nav
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/ros_marvelmind_package.git
+      version: 1.0.9-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `marvelmind_nav_lcas` to `1.0.9-0`:

- upstream repository: https://github.com/LCAS/ros_marvelmind_package.git
- release repository: https://github.com/lcas-releases/ros_marvelmind_package.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## marvelmind_nav

```
* ROS_INFOs along with topic publish are disabled
* changed maintainer
* added install targets
* Contributors: Marc Hanheide, gpdas, thorvald
```
