### PR TITLE
uol_cmp9767m: 0.1.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1104,10 +1104,11 @@ repositories:
     release:
       packages:
       - uol_cmp9767m_base
+      - uol_cmp9767m_tutorial
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/CMP9767M.git
-      version: 0.0.4-0
+      version: 0.1.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uol_cmp9767m` to `0.1.0-0`:

- upstream repository: https://github.com/LCAS/CMP9767M.git
- release repository: https://github.com/lcas-releases/CMP9767M.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.0.4-0`

## uol_cmp9767m_base

```
* fixed test
* Merge pull request #13 <https://github.com/LCAS/CMP9767M/issues/13> from gpdas/master
  sensor.xacro updated with working velodyne and kinect2.
* fixed gui conflict
* Merge branch 'master' into master
* sensor.xacro updated with velodyne and kinect2.
  raw urdf from the <sensor>_description added to sensors.xacro to avoid problems with tf_prefix and topic_names
* Merge pull request #12 <https://github.com/LCAS/CMP9767M/issues/12> from LCAS/rostest_marc
  added more meaningful rostests
* fixed install
* moved tests
* added more meaningful rostests
* Merge pull request #7 <https://github.com/LCAS/CMP9767M/issues/7> from LCAS/initial_map
  added cropped map
* added cropped map
* Contributors: Marc Hanheide, gpdas
```

## uol_cmp9767m_tutorial

```
* Merge branch 'master' into master
* Merge pull request #12 <https://github.com/LCAS/CMP9767M/issues/12> from LCAS/rostest_marc
  added more meaningful rostests
* fixed install
* moved tests
* added more meaningful rostests
* simple testing
* Contributors: Marc Hanheide
* Merge branch 'master' into master
* Merge pull request #12 <https://github.com/LCAS/CMP9767M/issues/12> from LCAS/rostest_marc
  added more meaningful rostests
* fixed install
* moved tests
* added more meaningful rostests
* simple testing
* Contributors: Marc Hanheide
```
