### PR TITLE
uol_cmp9767m: 0.1.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1108,7 +1108,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/CMP9767M.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uol_cmp9767m` to `0.1.1-0`:

- upstream repository: https://github.com/LCAS/CMP9767M.git
- release repository: https://github.com/lcas-releases/CMP9767M.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.1.0-0`

## uol_cmp9767m_base

```
* Update package.xml
* Contributors: Marc Hanheide
```

## uol_cmp9767m_tutorial

- No changes
