### PR TITLE
strands_ui: 0.2.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -991,7 +991,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_ui.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_ui` to `0.2.1-0`:

- upstream repository: https://github.com/strands-project/strands_ui.git
- release repository: https://github.com/strands-project-releases/strands_ui.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.2.0-0`

## mary_tts

```
* Merge pull request #109 <https://github.com/strands-project/strands_ui/issues/109> from francescodelduchetto/pull-req
  fix global variable declaration missing
* fix global variable declaration missing
* Contributors: Marc Hanheide, francescodelduchetto
```

## mongodb_media_server

- No changes

## music_player

- No changes

## pygame_managed_player

- No changes

## robot_talk

- No changes

## sound_player_server

- No changes

## strands_ui

- No changes

## strands_webserver

- No changes
