### PR TITLE
strands_navigation: 1.0.7-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -900,7 +900,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 1.0.6-0
+      version: 1.0.7-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `1.0.7-0`:

- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.0.6-0`

## emergency_behaviours

- No changes

## joy_map_saver

- No changes

## message_store_map_switcher

- No changes

## monitored_navigation

- No changes

## nav_goals_generator

- No changes

## pose_initialiser

- No changes

## strands_navigation

- No changes

## strands_navigation_msgs

- No changes

## topological_logging_manager

- No changes

## topological_navigation

```
* Temporarily disabling Morse-based tests (#360 <https://github.com/strands-project/strands_navigation/issues/360>)
* Contributors: Jaime Pulido Fentanes
```

## topological_rviz_tools

```
* added install for extra dirs (#365 <https://github.com/strands-project/strands_navigation/issues/365>)
* Merge pull request #364 <https://github.com/strands-project/strands_navigation/issues/364> from heuristicus/rviz_update
  Standalone easier to run on strands robots
* Standalone easier to run on strands robots
  Would have to run with rviz=false and then run rviz on the main PC if the
  database is on on of the side PCs. With this change can run the database on the
  side PC and then run this with launch_db:=false to not have to run rviz
  separately
* Contributors: Marc Hanheide, Michal Staniaszek, Nick Hawes
```

## topological_utils

```
* Merge pull request #354 <https://github.com/strands-project/strands_navigation/issues/354> from gpdas/indigo-devel
  tmap to yaml  - adding meta info to nodes
* Code cleanup
  Minor cleanup in usage information printing
* tmap to yaml export - adding meta info to nodes
  When a yaml file is created from a tmap, it misses some tags and so is not as per the (yaml) format for topological map. So a yaml file exported from tmap cannot be imported to mongodb.
  A small fix is done by adding some meta tag to the objects in the yaml file
* Contributors: Jaime Pulido Fentanes, gpdas
```
