### PR TITLE
strands_recovery_behaviours: 0.1.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -952,6 +952,18 @@ repositories:
       version: master
     status: developed
   strands_recovery_behaviours:
+    release:
+      packages:
+      - backoff_behaviour
+      - backtrack_behaviour
+      - strands_human_help
+      - strands_monitored_nav_states
+      - strands_recovery_behaviours
+      - walking_group_recovery
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_recovery_behaviours.git
+      version: 0.1.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_recovery_behaviours` to `0.1.0-0`:

- upstream repository: https://github.com/strands-project/strands_recovery_behaviours.git
- release repository: https://github.com/strands-project-releases/strands_recovery_behaviours.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `null`

## backoff_behaviour

- No changes

## backtrack_behaviour

- No changes

## strands_human_help

```
* Update help_screen.py
* Contributors: Bruno Lacerda
```

## strands_monitored_nav_states

```
* tidying
* Merge pull request #59 <https://github.com/strands-project/strands_recovery_behaviours/issues/59> from bfalacerda/hydro-devel
  christian's magic sequence for restarting motors
* christian's magic sequence for restarting motors
* Contributors: Bruno Lacerda, Nick Hawes
```

## strands_recovery_behaviours

```
* tidying
* Contributors: Bruno Lacerda
```

## walking_group_recovery

- No changes
