### PR TITLE
scitos_apps: 0.2.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -628,10 +628,11 @@ repositories:
       - scitos_ptu
       - scitos_teleop
       - scitos_touch
+      - scitos_virtual_bumper
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_apps.git
-      version: 0.1.2-0
+      version: 0.2.0-0
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_apps` to `0.2.0-0`:

- upstream repository: https://github.com/strands-project/scitos_apps.git
- release repository: https://github.com/strands-project-releases/scitos_apps.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.1.2-0`

## ptu_follow_frame

- No changes

## scitos_apps

- No changes

## scitos_cmd_vel_mux

- No changes

## scitos_dashboard

- No changes

## scitos_docking

```
* TKrajnik modifications: parameters for gains and ptu velocity (#164 <https://github.com/strands-project/scitos_apps/issues/164>)
* Contributors: francescodelduchetto
```

## scitos_ptu

- No changes

## scitos_teleop

```
* Updated email to new Oxford address
* Contributors: Nick Hawes
```

## scitos_touch

- No changes

## scitos_virtual_bumper

```
* adjusted version
* Merge pull request #162 <https://github.com/strands-project/scitos_apps/issues/162> from strands-project/marc-hanheide-patch-1
  added missing include_directories
* added missing include_directories
  see https://answers.ros.org/question/237494/fatal-error-rosrosh-no-such-file-or-directory/?answer=263025#post-id-263025
* Merge pull request #161 <https://github.com/strands-project/scitos_apps/issues/161> from gestom/virtual_bumper
  Virtual bumper
* Merge pull request #2 <https://github.com/strands-project/scitos_apps/issues/2> from Jailander/hydro-devel
  Improving notification information
* Improving notification information
* Merge pull request #1 <https://github.com/strands-project/scitos_apps/issues/1> from Jailander/hydro-devel
  Adding notifications to virtual bumper
* adding closest node to notification
* fixing typo
* Including Virtual Bumper notifications node
* Virtual bumper. When standing still, the robot automatically goes to free-run when pushed by a human. Free-run is turned off a few seconds after the robot is not moved anymore.
* Contributors: Jaime Pulido Fentanes, Marc Hanheide, Tom Krajnik
* adjusted version
* Merge pull request #162 <https://github.com/strands-project/scitos_apps/issues/162> from strands-project/marc-hanheide-patch-1
  added missing include_directories
* added missing include_directories
  see https://answers.ros.org/question/237494/fatal-error-rosrosh-no-such-file-or-directory/?answer=263025#post-id-263025
* Merge pull request #161 <https://github.com/strands-project/scitos_apps/issues/161> from gestom/virtual_bumper
  Virtual bumper
* Merge pull request #2 <https://github.com/strands-project/scitos_apps/issues/2> from Jailander/hydro-devel
  Improving notification information
* Improving notification information
* Merge pull request #1 <https://github.com/strands-project/scitos_apps/issues/1> from Jailander/hydro-devel
  Adding notifications to virtual bumper
* adding closest node to notification
* fixing typo
* Including Virtual Bumper notifications node
* Virtual bumper. When standing still, the robot automatically goes to free-run when pushed by a human. Free-run is turned off a few seconds after the robot is not moved anymore.
* Contributors: Jaime Pulido Fentanes, Marc Hanheide, Tom Krajnik
```
