### PR TITLE
slackeros: 0.1.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -696,7 +696,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/slackeros.git
-      version: 0.0.5-0
+      version: 0.1.0-0
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `slackeros` to `0.1.0-0`:

- upstream repository: https://github.com/marc-hanheide/slackeros.git
- release repository: https://github.com/lcas-releases/slackeros.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `0.0.5-0`

## slackeros

```
* Merge pull request #9 <https://github.com/marc-hanheide/slackeros/issues/9> from marc-hanheide/no_dropping
  massive refactoring and queue processing
* massive refactoring and queue processing
* Contributors: Marc Hanheide
```
