### PR TITLE
strands_executive: 1.2.4-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -814,7 +814,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 1.2.1-0
+      version: 1.2.4-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `1.2.4-0`:

- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.7`
- previous version for package: `1.2.1-0`

## gcal_routine

```
* Merge pull request #306 <https://github.com/strands-project/strands_executive/issues/306> from strands-project/marc-hanheide-patch-1
  making time-critical tasks a parameter
* making time-critical tasks a parameter
* merge
* Contributors: Marc Hanheide, Nick Hawes
```

## mdp_plan_exec

```
* merge
* Contributors: Nick Hawes
```

## prism_strands

```
* merge
* Contributors: Nick Hawes
```

## scheduler

```
* merge
* Contributors: Nick Hawes
```

## scipoptsuite

```
* merge
* Contributors: Nick Hawes
```

## sim_clock

```
* merge
* Contributors: Nick Hawes
```

## strands_executive_msgs

```
* Merge pull request #305 <https://github.com/strands-project/strands_executive/issues/305> from francescodelduchetto/pull-req
  cancel_active_task service result message has a boolean to acknowledg…
* cancel_active_task service result message has a boolean to acknowledge the termination of the task
* merge
* Contributors: Nick Hawes, francescodelduchetto
```

## task_executor

```
* Merge pull request #305 <https://github.com/strands-project/strands_executive/issues/305> from francescodelduchetto/pull-req
  cancel_active_task service result message has a boolean to acknowledg…
* cancel_active_task service result message has a boolean to acknowledge the termination of the task
* merge
* Updated examples and output
* Contributors: Nick Hawes, francescodelduchetto
```

## wait_action

```
* merge
* Contributors: Nick Hawes
```
