### PR TITLE
lcas_teaching: 0.2.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -279,14 +279,14 @@ repositories:
   lcas_teaching:
     release:
       packages:
-      - catkinized_downward
-      - uol_cmp3641m
+      - uol_cmp3103m
+      - uol_rpi_tbot
       - uol_turtlebot_common
       - uol_turtlebot_simulator
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/lcas_teaching.git
-      version: 0.1.18-0
+      version: 0.2.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lcas_teaching` to `0.2.0-0`:

- upstream repository: https://github.com/LCAS/teaching.git
- release repository: https://github.com/strands-project-releases/lcas_teaching.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.9`
- previous version for package: `0.1.18-0`
