### PR TITLE
sentor: 2.0.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -679,6 +679,11 @@ repositories:
       version: kinetic-devel
     status: developed
   sentor:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/sentor.git
+      version: 2.0.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sentor` to `2.0.1-0`:

- upstream repository: https://github.com/LCAS/sentor.git
- release repository: https://github.com/lcas-releases/sentor.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## sentor

```
* Merge pull request #1 <https://github.com/LCAS/sentor/issues/1> from LCAS/2.0
  Merging 2.0 into master with some modifications for release
* prepare for installation
* prettier prints and longer sleep in loop to avoid None in hz
* added timeout for lambdas and not published
* first commmit version 2.0: yaml file for configuration, singaling also for published, lambda funcs are specified in the yaml as a string
* ehm
* remove logs
* Merge branch 'master' of https://github.com/francescodelduchetto/sentor
* check log to be rem
* another small bit
* remove logs and madd another check to avoid duplicate msg expr in the same list
* some debug logs
* more waiting
* fix bug
* better handling of satsfied expressions as we don't drop anymore expression satisfied very close in time
* Update README.md
* gitignore
* comments and readme
* bug in list inserting elements
* monitoring either the frequency or the expression on msgs
* Merge branch 'master' of github.com:francescodelduchetto/sentor
* tab
* Update README.md
* warning message more significative
* Merge branch 'master' of github.com:francescodelduchetto/sentor
* comment
* elifs instead of ifs
* explanation on usage of filtering
* added possiblity to filter the value of messages and get a warning when it is satisfied
* slightly better printing
* only one warning message when the topic is not published anymore; better terminal printing
* Delete ROSTopicHz.pyc
* Update README.md
* Update README.md
* initial commit
* Contributors: Lindsey User, Marc Hanheide, francescodelduchetto
```
