### PR TITLE
mongodb_store: 0.5.0-4 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -2532,6 +2532,21 @@ repositories:
       url: https://github.com/ros/metapackages.git
       version: melodic-devel
     status: maintained
+  mongodb_store:
+    release:
+      packages:
+      - mongodb_log
+      - mongodb_store
+      - mongodb_store_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/strands-project-releases/mongodb_store.git
+      version: 0.5.0-4
+    source:
+      type: git
+      url: https://github.com/strands-project/mongodb_store.git
+      version: melodic-devel
+    status: developed
   move_base_flex:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.5.0-4`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.7.1`
- previous version for package: `null`

## mongodb_log

```
* Merge pull request #231 <https://github.com/strands-project/mongodb_store/issues/231> from bbferka/melodic-devel
  Melodic devel
* back to system mongo
* Contributors: Ferenc Balint-Benczedi, Nick Hawes
```

## mongodb_store

```
* Merge pull request #231 <https://github.com/strands-project/mongodb_store/issues/231> from bbferka/melodic-devel
  Melodic devel
* add dependency to package xml
* make it run
* back to system mongo
* Contributors: Ferenc Balint-Benczedi, Nick Hawes
```

## mongodb_store_msgs

- No changes
