### PR TITLE
strands_qsr_lib: 0.4.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -959,7 +959,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_qsr_lib.git
-      version: 0.4.0-0
+      version: 0.4.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_qsr_lib` to `0.4.1-0`:

- upstream repository: https://github.com/strands-project/strands_qsr_lib.git
- release repository: https://github.com/strands-project-releases/strands_qsr_lib.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.4.0-0`

## qsr_lib

```
* Solved casting issue. Testing on kinectic (#243 <https://github.com/strands-project/strands_qsr_lib/issues/243>)
* Contributors: Manuel Fernandez-Carmona
```

## qsr_prob_rep

```
* Typo in boolean (#244 <https://github.com/strands-project/strands_qsr_lib/issues/244>)
* Solved casting issue. Testing on kinectic (#243 <https://github.com/strands-project/strands_qsr_lib/issues/243>)
* Updated email to new Oxford address
* Contributors: Manuel Fernandez-Carmona, Nick Hawes
```

## strands_qsr_lib

- No changes
