### PR TITLE
strands_hri: 0.2.3-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -859,7 +859,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_hri.git
-      version: 0.2.2-0
+      version: 0.2.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_hri` to `0.2.3-0`:

- upstream repository: https://github.com/strands-project/strands_hri.git
- release repository: https://github.com/strands-project-releases/strands_hri.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.7.1`
- previous version for package: `0.2.2-0`

## han_action_dispatcher

- No changes

## hrsi_launch

```
* Update hrsi.launch (#157 <https://github.com/strands-project/strands_hri/issues/157>)
* Contributors: Tejas Prakash Madhukar Parekh
```

## hrsi_representation

```
* genjava fail patch (#158 <https://github.com/strands-project/strands_hri/issues/158>)
  * Namespaces and topic parametrized. Minor changes
  * Removed typos in default topic names
  * Missing file
  * added dependencies to solve errors when compiling with genjava
  * m.ch.
* Contributors: Manuel Fernandez-Carmona
```

## hrsi_state_prediction

- No changes

## hrsi_velocity_costmaps

- No changes

## strands_gazing

- No changes

## strands_hri

- No changes

## strands_hri_launch

- No changes

## strands_human_aware_navigation

- No changes

## strands_human_following

```
* genjava fail patch (#158 <https://github.com/strands-project/strands_hri/issues/158>)
  * Namespaces and topic parametrized. Minor changes
  * Removed typos in default topic names
  * Missing file
  * added dependencies to solve errors when compiling with genjava
  * m.ch.
* Contributors: Manuel Fernandez-Carmona
```

## strands_interaction_behaviours

- No changes

## strands_simple_follow_me

- No changes

## strands_visualise_speech

- No changes
