### PR TITLE
gazebo_contact_monitor: 1.0.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -133,7 +133,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/gazebo-contactMonitor.git
-      version: 1.0.0-0
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_contact_monitor` to `1.0.0-1`:

- upstream repository: https://github.com/LCAS/gazebo-contactMonitor.git
- release repository: https://github.com/lcas-releases/gazebo-contactMonitor.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-0`

## contact_monitor

```
* Merge pull request #2 <https://github.com/LCAS/gazebo-contactMonitor/issues/2> from pulver22/fix_gazebo_synch
  Fix gazebo synch
* Update contactMonitor.cpp
* Update contactMonitor.launch
* Update contactMonitor.cpp
  Do not create global vars unless necessary.
* Update contactMonitor.launch
  Don't remove functionallities
* Wait for gazebo generate the gz contacts topic before subscribe to it
* Wait for gazebo generate the gz contacts topic before subscribe to it
* Moved to spinOnce() to control the rate
* gazebo 8
* Merge pull request #1 <https://github.com/LCAS/gazebo-contactMonitor/issues/1> from pulver22/master
  Added full info to contact msgs + Clang refactor
* Added full contact information to ROS msg
* Added full contact information to ROS msg
* now publishing ALL collision names
* package renamed
* Update contactMonitor.cpp
* Update contactMonitor.launch
* Update README.md
* Initial commit
* Contributors: Manuel Fernandez-Carmona, Riccardo Polvara
```
