### PR TITLE
gazebo_contact_monitor: 1.1.0-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -133,7 +133,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/gazebo-contactMonitor.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_contact_monitor` to `1.1.0-0`:

- upstream repository: https://github.com/LCAS/gazebo-contactMonitor.git
- release repository: https://github.com/lcas-releases/gazebo-contactMonitor.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.7.2`
- previous version for package: `1.0.0-0`

## contact_monitor

```
* Topic namess follow the CCA rules. Added an error msg and 1s delay if no gz topic is found
* New README. Extra parameters added
* Update package.xml
  Added missing build dependence
* Contributors: Manuel Fernandez-Carmona
```
