### PR TITLE
tf_bag: 0.1.1-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1051,6 +1051,11 @@ repositories:
       version: kinetic-devel
     status: developed
   tf_bag:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/tf_bag.git
+      version: 0.1.1-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `tf_bag` to `0.1.1-0`:

- upstream repository: https://github.com/LCAS/tf_bag.git
- release repository: https://github.com/lcas-releases/tf_bag.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## tf_bag

```
* Changes for proper install
* Added install option
* Update package.xml
* Corrected package name in docs
  Fixes #3 <https://github.com/LCAS/tf_bag/issues/3>
* Merge pull request #2 <https://github.com/LCAS/tf_bag/issues/2> from gondsm/master
  Make tf_bag compatible with bags recorded with "tf" and "/tf" as topic names
  Fixes #1 <https://github.com/LCAS/tf_bag/issues/1>
* Make tf_bag compatible with bags recorded with "tf" and "/tf" as topic names.
* Fix double use of iterator in averageTransforms
* Fixed README readability
* Added LICENSE and improved .gitignore
* Initial commit with working version and README
* Contributors: Gonçalo S. Martins, Manue, Manuel Fernandez-Carmona, Marco Esposito
```
