### PR TITLE
thorvald: 0.2.3-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1103,7 +1103,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/thorvald-releases.git
-      version: 0.2.2-2
+      version: 0.2.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `0.2.3-0`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/LCAS/thorvald-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.2.2-2`

## thorvald

```
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_2dnav

```
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_base

```
* changelogs
* Merge pull request #57 <https://github.com/LCAS/Thorvald/issues/57> from larsgrim/kinetic-devel
  Support for new batteries and some simple gui tweaks
* moved motor controller modes to CanDriveItf to avoid dep on thorvald_base
* added motor controller modes to msg
* added support for 2.gen KC batteries
* Contributors: Marc Hanheide, larsgrim
* Merge pull request #57 <https://github.com/LCAS/Thorvald/issues/57> from larsgrim/kinetic-devel
  Support for new batteries and some simple gui tweaks
* moved motor controller modes to CanDriveItf to avoid dep on thorvald_base
* added motor controller modes to msg
* added support for 2.gen KC batteries
* Contributors: larsgrim
```

## thorvald_bringup

```
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_can_devices

```
* changelogs
* Merge pull request #57 <https://github.com/LCAS/Thorvald/issues/57> from larsgrim/kinetic-devel
  Support for new batteries and some simple gui tweaks
* removed unused includes in CanDriveItf.h
* removed couts from kc battery
* added mode for lost connection
* removed old, unused files
* now using enum in interface for modes
* moved motor controller modes to CanDriveItf to avoid dep on thorvald_base
* removed unused methods in drive itf
* added support for 2.gen KC batteries
* Contributors: Lars, Marc Hanheide, larsgrim
* Merge pull request #57 <https://github.com/LCAS/Thorvald/issues/57> from larsgrim/kinetic-devel
  Support for new batteries and some simple gui tweaks
* removed unused includes in CanDriveItf.h
* removed couts from kc battery
* added mode for lost connection
* removed old, unused files
* now using enum in interface for modes
* moved motor controller modes to CanDriveItf to avoid dep on thorvald_base
* removed unused methods in drive itf
* added support for 2.gen KC batteries
* Contributors: Lars, larsgrim
```

## thorvald_gazebo_plugins

```
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_gui

```
* changelogs
* Merge pull request #57 <https://github.com/LCAS/Thorvald/issues/57> from larsgrim/kinetic-devel
  Support for new batteries and some simple gui tweaks
* added some newlines in default gui motor controller list
* added support for 2.gen KC batteries
* Contributors: Marc Hanheide, larsgrim
* Merge pull request #57 <https://github.com/LCAS/Thorvald/issues/57> from larsgrim/kinetic-devel
  Support for new batteries and some simple gui tweaks
* added some newlines in default gui motor controller list
* added support for 2.gen KC batteries
* Contributors: larsgrim
```

## thorvald_model

```
* changelogs
* Merge pull request #58 <https://github.com/LCAS/Thorvald/issues/58> from adambinch/kinetic-devel
  Physical properties of the simulation set to something more realistic…
* Physical properties of the simulation set to something more realistic (please also see corresponding commit to the Thorvald repo).
  Friction added between thorvald model wheels (see Thorvald/thorvald_model/urdf/thorvald_model.xacro) and the gazebo ground plane (see RASberry/rasberry_gazebo/models/grass_ground_plane/model-1_4.sdf).
  Moments of inertia and mass values in Thorvald/thorvald_model/urdf/thorvald_model.xacro have been set to those measured from SolidWorks. Moments of inertia are those taken at the ouput coordinate system.
  It now takes approx 1,000 N of force to see significant movement in the robot model (measured by applying the force for a duration of 1 second).
* Contributors: Marc Hanheide, adambinch, larsgrim
* Merge pull request #58 <https://github.com/LCAS/Thorvald/issues/58> from adambinch/kinetic-devel
  Physical properties of the simulation set to something more realistic…
* Physical properties of the simulation set to something more realistic (please also see corresponding commit to the Thorvald repo).
  Friction added between thorvald model wheels (see Thorvald/thorvald_model/urdf/thorvald_model.xacro) and the gazebo ground plane (see RASberry/rasberry_gazebo/models/grass_ground_plane/model-1_4.sdf).
  Moments of inertia and mass values in Thorvald/thorvald_model/urdf/thorvald_model.xacro have been set to those measured from SolidWorks. Moments of inertia are those taken at the ouput coordinate system.
  It now takes approx 1,000 N of force to see significant movement in the robot model (measured by applying the force for a duration of 1 second).
* Contributors: adambinch, larsgrim
```

## thorvald_msgs

```
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_simulator

```
* changelogs
* Contributors: Marc Hanheide
```

## thorvald_teleop

```
* changelogs
* Merge pull request #53 <https://github.com/LCAS/Thorvald/issues/53> from eirikgarsol/kinetic-devel
  Adding logitech configuration template and adjusted teleop_node for compatibility
* Added config for logitech f710 controller
  Added parameters for left/forward drive mode button combo.
  changes to teleop_node: arrow button presses are in both axes and buttons vectors for xbox controllers, but only buttons vector for logitech
  to allow configuring the arrows as buttons, the joy axes values are now converted to int (or bool) and appended to the button vector
  **NOT TESTED WITH XBOX** xbox.yaml is modified to work as before (changing mode requires button_function to be pressed).
  Added methods to evaluate button and button combo presses.
* added parameters for default, min, max, delta speeds and button combo to reset to default speed. Modified teleop_node to check for button combo.
* twist_mux & teleop now agree on joy_pririty lock topic name
* Contributors: Marc Hanheide, eirikgarsol, larsgrim
* Merge pull request #53 <https://github.com/LCAS/Thorvald/issues/53> from eirikgarsol/kinetic-devel
  Adding logitech configuration template and adjusted teleop_node for compatibility
* Added config for logitech f710 controller
  Added parameters for left/forward drive mode button combo.
  changes to teleop_node: arrow button presses are in both axes and buttons vectors for xbox controllers, but only buttons vector for logitech
  to allow configuring the arrows as buttons, the joy axes values are now converted to int (or bool) and appended to the button vector
  **NOT TESTED WITH XBOX** xbox.yaml is modified to work as before (changing mode requires button_function to be pressed).
  Added methods to evaluate button and button combo presses.
* added parameters for default, min, max, delta speeds and button combo to reset to default speed. Modified teleop_node to check for button combo.
* twist_mux & teleop now agree on joy_pririty lock topic name
* Contributors: eirikgarsol, larsgrim
```

## thorvald_twist_mux

```
* changelogs
* Contributors: Marc Hanheide
```
