### PR TITLE
sentor: 2.0.2-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -724,7 +724,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/sentor.git
-      version: 2.0.1-0
+      version: 2.0.2-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sentor` to `2.0.2-0`:

- upstream repository: https://github.com/LCAS/sentor.git
- release repository: https://github.com/lcas-releases/sentor.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.0.1-0`

## sentor

```
* Merge pull request #2 <https://github.com/LCAS/sentor/issues/2> from francescodelduchetto/master
  update readme with description of config file usage
* rospy spin instead of 'handmade' spin
* print also the message together with the expression
* Merge branch 'master' into master
* Merge pull request #1 <https://github.com/LCAS/sentor/issues/1> from francescodelduchetto/2.0
  merge 2.0 to master
* Update README.md
* Update README.md
* Update README.md
* Update README.md
* Contributors: Marc Hanheide, francescodelduchetto
```
