### PR TITLE
sentor: 2.0.3-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -724,7 +724,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/sentor.git
-      version: 2.0.1-0
+      version: 2.0.3-0
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sentor` to `2.0.3-0`:

- upstream repository: https://github.com/LCAS/sentor.git
- release repository: https://github.com/lcas-releases/sentor.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.7.2`
- previous version for package: `2.0.1-0`

## sentor

```
* Merge pull request #3 <https://github.com/LCAS/sentor/issues/3> from francescodelduchetto/master
  fix some bugs
* Merge branch 'master' into master
* Merge branch 'master' of https://github.com/francescodelduchetto/sentor
* fix various errors
* Contributors: Lindsey User, Marc Hanheide
```
