### PR TITLE
slackeros: 0.2.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -763,7 +763,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/slackeros.git
-      version: 0.1.0-0
+      version: 0.2.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `slackeros` to `0.2.0-1`:

- upstream repository: https://github.com/marc-hanheide/slackeros.git
- release repository: https://github.com/lcas-releases/slackeros.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.0-0`

## slackeros

```
* Merge pull request #11 <https://github.com/marc-hanheide/slackeros/issues/11> from francescodelduchetto/master
  Uploading an image with each message sent
* parameter for img upload channels and take channel from payload when using slash command
* putting some try catches and parameter names
* fix missing parameters to be passed to ImageUPloader
* automatically select the encoding from the image msg
* possibility of uploading an image in the administration channel every time a message is sent
* Merge remote-tracking branch 'upstream/master'
* first attempt to images upload after any warning
* Contributors: Lindsey User, Marc Hanheide, francescodelduchetto
```
