### PR TITLE
ouster: 0.1.2-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -480,7 +480,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/ouster.git
-      version: 0.1.1-0
+      version: 0.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ouster` to `0.1.2-1`:

- upstream repository: https://github.com/LCAS/ouster_example.git
- release repository: https://github.com/lcas-releases/ouster.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.1-0`

## ouster_client

```
* Merge pull request #3 <https://github.com/LCAS/ouster_example/issues/3> from LCAS/scosar-dev
  Included roscpp in package.xml
* Included roscpp to package.xml of ouster_client
* Fix header dependencies
* Typo in CMakelist
* Fix CMakelist of ouster_client
* Contributors: Serhan Cosar, scosar
```

## ouster_ros

```
* Fix header dependencies
* Added tf2_geometry_msgs in CMakelist and package.xml
* Fix tf2 error in build
* Remove visualization example code and Fix timestamp problem
* Remove dependencies on ouster_viz
* Contributors: Serhan Cosar
```
