### PR TITLE
ouster: 0.1.4-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -480,7 +480,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/ouster.git
-      version: 0.1.3-1
+      version: 0.1.4-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ouster` to `0.1.4-1`:

- upstream repository: https://github.com/LCAS/ouster_example.git
- release repository: https://github.com/lcas-releases/ouster.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.1.3-1`

## ouster_client

```
* Uncomment a line in CMakeLists
* Contributors: scosar
```

## ouster_ros

- No changes
