### PR TITLE
slackeros: 0.2.1-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -763,7 +763,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/slackeros.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `slackeros` to `0.2.1-1`:

- upstream repository: https://github.com/marc-hanheide/slackeros.git
- release repository: https://github.com/lcas-releases/slackeros.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.0-1`

## slackeros

```
* Merge pull request #12 <https://github.com/marc-hanheide/slackeros/issues/12> from marc-hanheide/format_and_name
  Format and name
* identify author as hostname
* mostly formatting
* Contributors: Marc Hanheide
```
