### PR TITLE
strands_navigation: 1.0.8-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -957,7 +957,6 @@ repositories:
       packages:
       - emergency_behaviours
       - joy_map_saver
-      - message_store_map_switcher
       - monitored_navigation
       - nav_goals_generator
       - pose_initialiser
@@ -970,7 +969,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 1.0.7-0
+      version: 1.0.8-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `1.0.8-1`:

- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.7-0`

## emergency_behaviours

```
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_navigation into indigo-devel
* Merge pull request #369 <https://github.com/strands-project/strands_navigation/issues/369> from strands-project/ori-indigo-devel
  Support for multi-robot and different global planners
* Fixed typo and maintaining backward compatibility for policy visualisation
* Merge remote-tracking branch 'ori/indigo-devel' into indigo-devel
  Bringing in changes from ORI for multi-robot and different base planners.
* Merge branch 'indigo-devel' of https://github.com/bfalacerda/strands_navigation into indigo-devel
* update of absolute/relative topic names for multi-robot setup
* Contributors: Bruno Lacerda, Nick Hawes
```

## joy_map_saver

```
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_navigation into indigo-devel
* Merge pull request #369 <https://github.com/strands-project/strands_navigation/issues/369> from strands-project/ori-indigo-devel
  Support for multi-robot and different global planners
* Merge remote-tracking branch 'ori/indigo-devel' into indigo-devel
  Bringing in changes from ORI for multi-robot and different base planners.
* update of absolute/relative topic names for multi-robot setup
* Contributors: Bruno Lacerda, Nick Hawes
```

## monitored_navigation

```
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_navigation into indigo-devel
* Merge pull request #369 <https://github.com/strands-project/strands_navigation/issues/369> from strands-project/ori-indigo-devel
  Support for multi-robot and different global planners
* Merge remote-tracking branch 'ori/indigo-devel' into indigo-devel
  Bringing in changes from ORI for multi-robot and different base planners.
* update of absolute/relative topic names for multi-robot setup
* Contributors: Bruno Lacerda, Nick Hawes
```

## nav_goals_generator

```
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_navigation into indigo-devel
* Contributors: Bruno Lacerda
```

## pose_initialiser

```
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_navigation into indigo-devel
* Contributors: Bruno Lacerda
```

## strands_navigation

```
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_navigation into indigo-devel
* Contributors: Bruno Lacerda
```

## strands_navigation_msgs

```
* Merge pull request #374 <https://github.com/strands-project/strands_navigation/issues/374> from Jailander/edge-reconf
  Move base parameters being reconfigured at edges
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_navigation into indigo-devel
* Moving reconf server to strands
* Merge pull request #369 <https://github.com/strands-project/strands_navigation/issues/369> from strands-project/ori-indigo-devel
  Support for multi-robot and different global planners
* Merge remote-tracking branch 'ori/indigo-devel' into indigo-devel
  Bringing in changes from ORI for multi-robot and different base planners.
* correct feedback publishing from topo nav
* Contributors: Bruno Lacerda, Jaime Pulido Fentanes, Nick Hawes
```

## topological_logging_manager

```
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_navigation into indigo-devel
* Merge pull request #369 <https://github.com/strands-project/strands_navigation/issues/369> from strands-project/ori-indigo-devel
  Support for multi-robot and different global planners
* Merge remote-tracking branch 'ori/indigo-devel' into indigo-devel
  Bringing in changes from ORI for multi-robot and different base planners.
* Merge branch 'indigo-devel' of https://github.com/bfalacerda/strands_navigation into indigo-devel
* update of absolute/relative topic names for multi-robot setup
* Contributors: Bruno Lacerda, Nick Hawes
```

## topological_navigation

```
* Merge pull request #374 <https://github.com/strands-project/strands_navigation/issues/374> from Jailander/edge-reconf
  Move base parameters being reconfigured at edges
* Merge pull request #373 <https://github.com/strands-project/strands_navigation/issues/373> from bfalacerda/indigo-devel
  add local planner arg to single robot topo nav launch
* Merge pull request #1 <https://github.com/strands-project/strands_navigation/issues/1> from gpdas/edge-reconf
  reconfig_at_edges services added
* update current_edge_group only if reconfig successful
  reconf_at_edges service node now subscribes to param /edge_nav_reconfig_groups (removed relative ns)
* reconfig_at_edges services added
  1. edges_groups param is modified to have the parameter names and values for reconfiguration
  2. added a node in topological_navigation for running the reconf_at_edges service - @adambinch
  3. topological_navigation/navigation.py updated to use the modified param
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_navigation into indigo-devel
* add local planner arg to single robot topo nav launch
* Moving reconf server to strands
* reconfiguring when no group (so default option can be used)
* Reverting test
* testing
* Now resetting to the right set of params
* bug fix
* Re-configuring tolerance from latest set of parameters not original set
* adding edge reconfigure manager
* Corrected battery namespaces for localise by topic
* Merge pull request #369 <https://github.com/strands-project/strands_navigation/issues/369> from strands-project/ori-indigo-devel
  Support for multi-robot and different global planners
* minor changes to work with move_base_flex. defaults should produce backward compatible behaviour still
* Fixed typo and maintaining backward compatibility for policy visualisation
* Corrected indentation
* Merge remote-tracking branch 'ori/indigo-devel' into indigo-devel
  Bringing in changes from ORI for multi-robot and different base planners.
* respawn travel estimator when it dies
* Using correct exception type for dynparam call
* add different color to policy arrows
* Updated top nav execution to handled different types of local planner for move_base.
  Tested under navigation and policy execution, but not extensively.
* Minimal topological navigation config with no extra dependencies and no monitored nav recoveries
* top nav supports other planners for dynparam. still need to update policy exec
* making topo nav feedback more robutst to possible lag in localisation - fetch issues
* making sure number of fails gets reset after the fail threshold is reached
* make code less contrived
* correct feedback publishing from topo nav
* multi-robot setup
* update of absolute/relative topic names for multi-robot setup
* Contributors: Bruno Lacerda, Jaime Pulido Fentanes, Marc Hanheide, Nick Hawes, gpdas
```

## topological_rviz_tools

```
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_navigation into indigo-devel
* Merge pull request #369 <https://github.com/strands-project/strands_navigation/issues/369> from strands-project/ori-indigo-devel
  Support for multi-robot and different global planners
* Merge remote-tracking branch 'ori/indigo-devel' into indigo-devel
  Bringing in changes from ORI for multi-robot and different base planners.
* update of absolute/relative topic names for multi-robot setup
* Contributors: Bruno Lacerda, Nick Hawes
```

## topological_utils

```
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_navigation into indigo-devel
* Merge pull request #370 <https://github.com/strands-project/strands_navigation/issues/370> from gpdas/plot_topo_map
  plot_topo_map
* minor change
* plot_topo_map
  A script for plotting the current topological map being published to /topological_map topic
* Corrected battery namespaces for localise by topic
* Merge pull request #369 <https://github.com/strands-project/strands_navigation/issues/369> from strands-project/ori-indigo-devel
  Support for multi-robot and different global planners
* Merge remote-tracking branch 'ori/indigo-devel' into indigo-devel
  Bringing in changes from ORI for multi-robot and different base planners.
* update dummy topo nav to use new feedback msg
* update of absolute/relative topic names for multi-robot setup
* Contributors: Bruno Lacerda, Jaime Pulido Fentanes, Nick Hawes, gpdas
```
