### PR TITLE
mod_ros: 0.0.4-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -355,10 +355,11 @@ repositories:
     release:
       packages:
       - cliffmap_ros
+      - cliffmap_rviz_plugin
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
-      version: 0.0.2-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/ksatyaki/mod_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mod_ros` to `0.0.4-0`:

- upstream repository: https://github.com/ksatyaki/mod_ros.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.0.2-0`

## cliffmap_ros

```
* Very few minor updates
* Contributors: Chittaranjan Swaminathan
```

## cliffmap_rviz_plugin

```
* First CLiFFmap RViz Plugin. Also the best.
* Contributors: Chittaranjan Swaminathan
```
