### PR TITLE
mod_ros: 0.0.5-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -356,10 +356,13 @@ repositories:
       packages:
       - cliffmap_ros
       - cliffmap_rviz_plugin
+      - pedsim_scenarios
+      - stefmap_ros
+      - stefmap_rviz_plugin
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/ksatyaki/mod_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mod_ros` to `0.0.5-0`:

- upstream repository: https://github.com/ksatyaki/mod_ros.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.7.2`
- previous version for package: `0.0.4-0`

## pedsim_scenarios

```
* Remove dependencies for pedsim_scenarios
* Contributors: Chittaranjan Srinivas Swaminathan, Chittaranjan Swaminathan
```

## stefmap_ros

```
* STeF-map ROS is now part of MoD ROS package.
* Contributors: Chittaranjan Srinivas Swaminathan, Chittaranjan Swaminathan
```
