### PR TITLE
ompl_planners: 0.0.2-0 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -428,6 +428,14 @@ repositories:
       version: master
     status: developed
   ompl_planners:
+    release:
+      packages:
+      - ompl_mod_objectives
+      - ompl_planners_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://gitsvn-nt.oru.se/iliad/software/releases/ompl_planners.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/ksatyaki/ompl_planners.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl_planners` to `0.0.2-0`:

- upstream repository: https://github.com/ksatyaki/ompl_planners.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/ompl_planners.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.7.2`
- previous version for package: `null`

## ompl_mod_objectives

```
* Update package.xml
* Add install targets
* Move MoD to separate package. STeFMap planning works.
* Contributors: Chittaranjan Srinivas Swaminathan, Chittaranjan Swaminathan
```

## ompl_planners_ros

```
* Fix bugs. Small info improvements.
* Add ncfm maps
* Adjust licenses
* Refactoring - further
* Contributors: Chittaranjan Srinivas Swaminathan, Chittaranjan Swaminathan
```
