### PR TITLE
pcl_detector: 0.0.3-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -530,7 +530,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/pcl_detector.git
-      version: 0.0.2-0
+      version: 0.0.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `pcl_detector` to `0.0.3-1`:

- upstream repository: https://github.com/LCAS/pcl_detector.git
- release repository: https://github.com/lcas-releases/pcl_detector.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.2-0`

## object3d_detector

```
* Merge pull request #3 <https://github.com/LCAS/pcl_detector/issues/3> from scosar/master
  Input parameter to set lidar topic
* Merge remote-tracking branch 'upstream/master'
* Included a parameter to set input lidar topic
* Contributors: Serhan Cosar, scosar
```
