### PR TITLE
mod_ros: 0.0.6-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -362,7 +362,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
-      version: 0.0.5-0
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/ksatyaki/mod_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mod_ros` to `0.0.6-1`:

- upstream repository: https://github.com/ksatyaki/mod_ros.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.5-0`

## cliffmap_ros

```
* Add eigen to package.xml
* Contributors: Chittaranjan Swaminathan
```

## cliffmap_rviz_plugin

- No changes

## pedsim_scenarios

- No changes

## stefmap_ros

- No changes

## stefmap_rviz_plugin

- No changes
