### PR TITLE
ompl_planners: 0.0.6-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -435,7 +435,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/ompl_planners.git
-      version: 0.0.5-1
+      version: 0.0.6-1
     source:
       type: git
       url: https://github.com/ksatyaki/ompl_planners.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl_planners` to `0.0.6-1`:

- upstream repository: https://github.com/ksatyaki/ompl_planners.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/ompl_planners.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.5-1`

## ompl_mod_objectives

```
* Fix install target error
```

## ompl_planners_ros

```
* Fix install target for param folder.
```
