### PR TITLE
thorvald: 1.1.0-2 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1156,7 +1156,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/thorvald-releases.git
-      version: 1.1.0-1
+      version: 1.1.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `1.1.0-2`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/LCAS/thorvald-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.0-1`

## thorvald

- No changes

## thorvald_2dnav

- No changes

## thorvald_base

- No changes

## thorvald_bringup

```
* Merge pull request #67 <https://github.com/LCAS/Thorvald/issues/67> from c-small/kinetic-devel
  Tall robot simulation
* Tall robot files
* Contributors: Jaime Pulido Fentanes, c-small
```

## thorvald_can_devices

- No changes

## thorvald_description

```
* Merge pull request #67 <https://github.com/LCAS/Thorvald/issues/67> from c-small/kinetic-devel
  Tall robot simulation
* Tall robot files
* Contributors: Jaime Pulido Fentanes, c-small
```

## thorvald_example_robots

```
* Merge pull request #67 <https://github.com/LCAS/Thorvald/issues/67> from c-small/kinetic-devel
  Tall robot simulation
* Tall robot files
* GPS frame added to xacro
* Added gps gazebo plugin and gps to urdf.
* Contributors: Jaime Pulido Fentanes, c-small
```

## thorvald_gazebo_plugins

- No changes

## thorvald_gui

- No changes

## thorvald_msgs

- No changes

## thorvald_simulator

- No changes

## thorvald_teleop

- No changes

## thorvald_twist_mux

- No changes
