### PR TITLE
thorvald: 1.1.1-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1156,7 +1156,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/thorvald-releases.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `1.1.1-1`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/LCAS/thorvald-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.0-1`

## thorvald

- No changes

## thorvald_2dnav

- No changes

## thorvald_base

```
* Merge pull request #71 <https://github.com/LCAS/Thorvald/issues/71> from LCAS/marc-hanheide-patch-1
  make rate configurable
* make rate configurable
  The idea is to make the publish rate configurable
* Merge pull request #69 <https://github.com/LCAS/Thorvald/issues/69> from larsgrim/kinetic-devel
  Battery status, GUI mods, missing installs
* added status to battery
* Contributors: Marc Hanheide, larsgrim
```

## thorvald_bringup

- No changes

## thorvald_can_devices

```
* Merge pull request #69 <https://github.com/LCAS/Thorvald/issues/69> from larsgrim/kinetic-devel
  Battery status, GUI mods, missing installs
* added status to battery
* Contributors: larsgrim
```

## thorvald_description

- No changes

## thorvald_example_robots

```
* Merge pull request #69 <https://github.com/LCAS/Thorvald/issues/69> from larsgrim/kinetic-devel
  Battery status, GUI mods, missing installs
* now installs config, meshes and urdf directories
* Contributors: larsgrim
```

## thorvald_gazebo_plugins

- No changes

## thorvald_gui

```
* Merge pull request #69 <https://github.com/LCAS/Thorvald/issues/69> from larsgrim/kinetic-devel
  Battery status, GUI mods, missing installs
* replaced Saga logo with Thorvald logo and removed some prints
* added enc board stuff to gui
* added status to battery
* Contributors: larsgrim
```

## thorvald_msgs

- No changes

## thorvald_simulator

- No changes

## thorvald_teleop

- No changes

## thorvald_twist_mux

- No changes
