### PR TITLE
thorvald: 1.1.2-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1156,7 +1156,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/thorvald-releases.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `1.1.2-1`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/LCAS/thorvald-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.1.1-1`

## thorvald

- No changes

## thorvald_2dnav

- No changes

## thorvald_base

```
* fixed stupid bug
* Contributors: Marc Hanheide
```

## thorvald_bringup

- No changes

## thorvald_can_devices

- No changes

## thorvald_description

- No changes

## thorvald_example_robots

- No changes

## thorvald_gazebo_plugins

- No changes

## thorvald_gui

- No changes

## thorvald_msgs

- No changes

## thorvald_simulator

- No changes

## thorvald_teleop

- No changes

## thorvald_twist_mux

- No changes
