### PR TITLE
optis_drivers: 1.1.2-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -456,6 +456,13 @@ repositories:
       version: 0.0.11-0
     status: maintained
   optis_drivers:
+    release:
+      packages:
+      - optris_drivers
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/optis_drivers.git
+      version: 1.1.2-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `optis_drivers` to `1.1.2-1`:

- upstream repository: https://github.com/LCAS/optris_drivers.git
- release repository: https://github.com/lcas-releases/optis_drivers.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## optris_drivers

```
* more deps
* more deps
* added udev as a hack to work around broken irlibimager
* Contributors: Marc Hanheide
```
