### PR TITLE
iliad_distribution: 0.1.0-2 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -174,15 +174,11 @@ repositories:
   iliad_distribution:
     release:
       packages:
-      - iliad_distribution
-      - iliad_launch_manipulation
-      - iliad_launch_navigation
       - iliad_launch_system
-      - iliad_restricted
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/iliad_distribution.git
-      version: 0.0.8-0
+      version: 0.1.0-2
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_distribution` to `0.1.0-2`:

- upstream repository: https://gitsvn-nt.oru.se/iliad/software/iliad_metapackage.git
- release repository: https://github.com/lcas-releases/iliad_distribution.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.8-0`

## iliad_launch_system

```
* update coordination config file
* Merge branch 'master' of https://gitsvn-nt.oru.se/iliad/software/iliad_metapackage
* Fixes
* change in coordinator.yaml
* Fix for bt launch
* Some changes to bt launch scripts
* Move calib file to right location
* Add proper robot6.yaml
* Delete robot6.yaml
* Merge branch 'bt-wip' of gitsvn-nt.oru.se:iliad/software/iliad_metapackage
* Fix floor laser topic again
* changed prefix of reflex topics
* Contributors: BT Truck, BT2, Chittaranjan S Swaminathan, Chittaranjan Swaminathan, Federico Pecora
```
