### PR TITLE
um7: 0.0.6-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1254,6 +1254,11 @@ repositories:
       version: master
     status: maintained
   um7:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/um7.git
+      version: 0.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `um7` to `0.0.6-1`:

- upstream repository: https://github.com/LCAS/um7.git
- release repository: https://github.com/lcas-releases/um7.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## um7

```
* fix deps
* Merge pull request #1 <https://github.com/LCAS/um7/issues/1> from MikHut/fix_enu_tf_lcas
  Fix enu tf
* add maintainer
* install target for launch file
* added launch file
* fix enu tf error and add param for yaw offset
* Fixed linter errors.
* Contributors: Jaime Pulido Fentanes, Marc Hanheide, MikHut, Tony Baltovski
```
