### PR TITLE
uol_cmp9767m: 0.3.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1273,7 +1273,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/CMP9767M.git
-      version: 0.2.0-0
+      version: 0.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uol_cmp9767m` to `0.3.0-1`:

- upstream repository: https://github.com/LCAS/CMP9767M.git
- release repository: https://github.com/lcas-releases/CMP9767M.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.2.0-0`

## uol_cmp9767m_base

```
* fixed new thorvald (#37 <https://github.com/LCAS/CMP9767M/issues/37>)
* Tutorial9 (#22 <https://github.com/LCAS/CMP9767M/issues/22>)
  * tutorial9 files
  * fixes
  * fixes 2
  * adding robot frame prefix to config files
  * using amcl instead of fake localization
  * improve simulation performance
* Fix greg (#17 <https://github.com/LCAS/CMP9767M/issues/17>)
  * Moved workshop files into a single repo
  * Dependency fixes
  * Nodelet/PCL dependency fix
  * Fixed warning: package uol_cmp9767m_base should not depend on metapackage thorvald_simulator but on its packages instead
* Contributors: Marc Hanheide, gcielniak
```

## uol_cmp9767m_tutorial

```
* fixed new thorvald (#37 <https://github.com/LCAS/CMP9767M/issues/37>)
* Merge pull request #25 <https://github.com/LCAS/CMP9767M/issues/25> from gpdas/tutorial_12
  Tutorial 12
* ros action related files
  1. added an example action DoDishes.action
  2. two scripts to demonstrate do_dishes action server and client
  3. one script to demonstrate topological_navigation action client
  4. minor changes to CMakeLists.txt and package.xml
* corrections to move_base_topo_nav.launch
  1. laser_scan_sensor topic and frame corrected for namespaced thorvalds
  2. footprint modified for the wide robot config
  3. create_new_topo_map.launch updated
* Tutorial 12 - Topological Navigation
  New dependency -> topological_navigation
  New launch files
  - move_base_topo_nav: for launching map_server, and namespaced versions of fake_localization, robot_pose_publisher and move_base
  - topo_nav: for launching topological_navigation related nodes
  - create_new_topo_map: for starting a new topo_map in the mongodb
  New configs
  - planner_topo_nav: TrajectoryPlannerROS is not supported by topological_navigation (yaw_goal_tolerance is not a reconfigurable parameter). So this one uses DWAPlannerROS by default. Some additional constraints on velocity(no Y and min_x=0)
  - planner: default set to a non-holonomic robot
  New topo_map -> test.yaml containing 6 nodes
* Merge pull request #24 <https://github.com/LCAS/CMP9767M/issues/24> from LCAS/tutorial10
  Merging. fake_localization fix. [jenkins build](https://lcas.lincoln.ac.uk/buildfarm/job/Kpr__uol_cmp9767m__ubuntu_xenial_amd64/33/) successfully completed, but somehow the status was not reached here.
* fake_localization fix
* Merge pull request #23 <https://github.com/LCAS/CMP9767M/issues/23> from LCAS/tutorial10
  Tutorial10 - had to merge myself ahead of the workshop.
* improved organisation of tutorial10 files
* rviz config
* tutorial10
* Tutorial9 (#22 <https://github.com/LCAS/CMP9767M/issues/22>)
  * tutorial9 files
  * fixes
  * fixes 2
  * adding robot frame prefix to config files
  * using amcl instead of fake localization
  * improve simulation performance
* tutorial8 files (#19 <https://github.com/LCAS/CMP9767M/issues/19>)
* Moved workshop files into a single repo (#16 <https://github.com/LCAS/CMP9767M/issues/16>)
  * Moved workshop files into a single repo
  * Dependency fixes
  * Nodelet/PCL dependency fix
* Contributors: Gautham P Das, Grzegorz Cielniak, Marc Hanheide, gcielniak, gpdas
```
