### PR TITLE
kmo_interfaces: 0.1.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -247,10 +247,11 @@ repositories:
       - kmo_fork_control
       - kmo_navserver
       - sick_s3x
+      - vmc_navserver
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/iliad-project/kmo_interfaces-release.git
-      version: 0.0.4-0
+      version: 0.1.0-1
     source:
       test_pull_requests: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kmo_interfaces` to `0.1.0-1`:

- upstream repository: https://gitsvn-nt.oru.se/marc-hanheide/kmo_interfaces.git
- release repository: https://github.com/iliad-project/kmo_interfaces-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.4-0`

## kmo_cpi_interface

```
* Merge branch 'master' of https://gitsvn-nt.oru.se/software/kmo_interfaces
* Merge branch 'master' of https://gitsvn-nt.oru.se/ksatyaki/kmo_interfaces
* Merge branch 'master' of gitsvn-nt.oru.se:software/kmo_interfaces
* Merge branch 'master' into 'master'
  Some missing dependencies and version numbering used in the release process
  See merge request !1
* Added bt truck test program for fork sensors.
* Added host port access functions.
* Added code for communicating / testing the fork at the BT truck.
* Contributors: BT Truck, Henrik Andreasson, Marc Hanheide
```

## kmo_fork_control

```
* Merge branch 'master' of https://gitsvn-nt.oru.se/software/kmo_interfaces
* Merge branch 'master' into 'master'
  Updated to accommodate namespace changes
  See merge request !2
* Merge all changes
* final commit ns change
* Merge branch 'master' of https://gitsvn-nt.oru.se/ksatyaki/kmo_interfaces
* Merge branch 'master' of gitsvn-nt.oru.se:software/kmo_interfaces
* Merge branch 'master' into 'master'
  Some missing dependencies and version numbering used in the release process
  See merge request !1
* Added node to readout forkdata from the BT truck.
* Contributors: BT Truck, Chittaranjan Swaminathan, Henrik Andreasson, Marc Hanheide
```

## kmo_navserver

```
* made same as upstream
* Merge branch 'master' of https://gitsvn-nt.oru.se/software/kmo_interfaces
* Fix topics for both robots
* Changes
* Added generic arg to onboard launch files
* correct mistake in roslaunch arg
* correct mistake in roslaunch arg
* Adjust frames for backwards compatibility
* Fix the ndt topics to be bound to the individual robots
* fix polluting output
* Merge branch 'master' into 'master'
  Fix the tf frames... yet again
  See merge request !3
* Fix the tf frames... yet again
* Merge branch 'master' into 'master'
  Updated to accommodate namespace changes
  See merge request !2
* adjust proper frame ids and params for them
* adjust proper frame ids and params for them
* Merge all changes
* adjust proper frame ids and params for them
* Merge branch 'master' into 'master'
  Merge with master
  See merge request !1
* typo
* laser frame ids parametrized
* final commit ns change
* Merge branch 'master' of https://gitsvn-nt.oru.se/ksatyaki/kmo_interfaces
* Changes for ns change
* frame id update - wip
* wip: some changes to allow different topic names
* Merge branch 'master' of https://gitsvn-nt.oru.se/ksatyaki/kmo_interfaces
* WIP naming convensions
* WIP naming convensions
* Fixed EPU protcol 2/8 problem.
* Added sample EPU external position example.
* Merge branch 'master' of gitsvn-nt.oru.se:software/kmo_interfaces
* exposed protocol version to launch file
* Merge branch 'master' into 'master'
  Some missing dependencies and version numbering used in the release process
  See merge request !1
* Contributors: BT Truck, Chittaranjan Swaminathan, Citi1, Henrik Andreasson, ILIAD user, Manuel Fernandez-Carmona, Manuel Fernández, Marc Hanheide, Robot5, citi2, tsv
```

## sick_s3x

```
* Merge branch 'master' of gitsvn-nt.oru.se:software/kmo_interfaces
* Merge branch 'master' into 'master'
  Some missing dependencies and version numbering used in the release process
  See merge request !1
* Contributors: Henrik Andreasson
```

## vmc_navserver

```
* Merge branch 'master' of https://gitsvn-nt.oru.se/software/kmo_interfaces
* Merge branch 'master' of https://gitsvn-nt.oru.se/ksatyaki/kmo_interfaces
* Added vmc_navserver/msg.
* Contributors: BT Truck, Henrik Andreasson, Marc Hanheide
```
