### PR TITLE
mod_ros: 1.0.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -367,13 +367,15 @@ repositories:
       packages:
       - cliffmap_ros
       - cliffmap_rviz_plugin
+      - gmmtmap_ros
+      - gmmtmap_rviz_plugin
       - pedsim_scenarios
       - stefmap_ros
       - stefmap_rviz_plugin
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
-      version: 0.0.7-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/ksatyaki/mod_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mod_ros` to `1.0.0-1`:

- upstream repository: https://github.com/ksatyaki/mod_ros.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.0.7-1`

## cliffmap_ros

```
* Bug fixes. CLiFF-map p and q values were not read properly before.
```

## gmmtmap_ros

```
* GMMT-map (Bennewitz et al. - Learning motion patterns of people...)
* Contributors: Chittaranjan Swaminathan, Johan Feinestam
```

## gmmtmap_rviz_plugin

```
* Added an rviz plugin for gmmtmaps
* Contributors: Chittaranjan Swaminathan
```
