### PR TITLE
iliad_human_perception: 1.0.7-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -207,7 +207,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception_release.git
-      version: 1.0.6-0
+      version: 1.0.7-1
     source:
       type: git
       url: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_human_perception` to `1.0.7-1`:

- upstream repository: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception_release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.6-0`

## iliad_human_perception_launch

```
* Fix typo
* Update install targets
* Merge branch 'master' of https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception
* Merge branch 'master' of https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception
* modifies CMakeList for new reflex node
* modifies reflex script to reuse TF from incoming msg
* new script for reflex_to_detected_persons
* Updates to person detection pipeline
* Do not delete processed bagfiles per default
* Update track initiation settings for ORU/Orkla
* Playback also world frame transform
* Add node for filtering detections when fork is up. Not yet included in primary detector startup launch file
* Tuning tracking params for Kinect v2
* Small fixes to person tracking pipeline/filtering
* In playback.launch, include cititruck_bringup instead of robotX.launch with sim:=false to make sure that Kinect v2 Gazebo stuff does not get loaded, while also not starting hardware drivers.
* Fix regression in playback.launch due to change in iliad_launch_system. Only tested with cititrucks, not bt_truck so far.
* Add script to generate video from bagfiles
* Minor fix
* Added covariance to detectedPerson so that tracker does not discart the measurement for having a 0 covariance matrix
* Contributors: Manuel Fernandez-Carmona, Robert Schirmer, Timm Linder
```
