### PR TITLE
rgbd_gpu_detector: 2.0.4-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -654,7 +654,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/rgbd_gpu_detector.git
-      version: 2.0.3-0
+      version: 2.0.4-1
     source:
       type: git
       url: https://gitsvn-nt.oru.se/linder/rgbd_gpu_detector.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rgbd_gpu_detector` to `2.0.4-1`:

- upstream repository: https://gitsvn-nt.oru.se/linder/rgbd_gpu_detector.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/rgbd_gpu_detector.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `2.0.3-0`

## rgbd_gpu_person_detector

```
* Parametrize params
* Parametrize backward shift, default to 0 (better according to Narunas' experiments)
* Contributors: Timm Linder
```
