### PR TITLE
iliad_smp: 0.3.1-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -228,7 +228,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/restricted-releases.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_smp` to `0.3.1-1`:

- upstream repository: https://gitsvn-nt.oru.se/palmieri/iliad_smp.git
- release repository: https://github.com/LCAS/restricted-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.3.0-1`

## iliad_smp_global_planner

```
* Adding modality parameter to select the planner from the hierarchical planning node (i.e. 0 means hierarchical, 1 for SMP, 2 for lattice).
* Contributors: Luigi Palmieri (Robert Bosch GmbH, CR/AER)
```
