### PR TITLE
iliad_human_perception: 1.0.15-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -208,7 +208,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception_release.git
-      version: 1.0.12-1
+      version: 1.0.15-1
     source:
       type: git
       url: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception.git


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_human_perception` to `1.0.15-1`:

- upstream repository: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/iliad_human_perception_release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `1.0.12-1`

## iliad_human_perception_launch

- No changes

## iliad_leg_tracker

```
* Add missing config and launch folders
* Contributors: Timm Linder
```
