### PR TITLE
franka_ros_lcas: 0.8.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -93,6 +93,20 @@ repositories:
       version: indigo-devel
     status: maintained
   franka_ros_lcas:
+    release:
+      packages:
+      - franka_control
+      - franka_description
+      - franka_example_controllers
+      - franka_gripper
+      - franka_hw
+      - franka_msgs
+      - franka_ros
+      - franka_visualization
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/franka_ros.git
+      version: 0.8.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_ros_lcas` to `0.8.0-1`:

- upstream repository: https://github.com/LCAS/franka_ros.git
- release repository: https://github.com/lcas-releases/franka_ros.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`
