### PR TITLE
rosbridge_suite_lcas: 0.12.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -708,6 +708,17 @@ repositories:
       version: master
     status: developed
   rosbridge_suite_lcas:
+    release:
+      packages:
+      - rosapi
+      - rosbridge_library
+      - rosbridge_msgs
+      - rosbridge_server
+      - rosbridge_suite
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/rosbridge_suite.git
+      version: 0.12.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosbridge_suite_lcas` to `0.12.0-1`:

- upstream repository: https://github.com/LCAS/rosbridge_suite.git
- release repository: https://github.com/lcas-releases/rosbridge_suite.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `null`

## rosapi

```
* changed maintainer
* Revert "changelogs"
  This reverts commit bfc023af331ee980c558858fb03cfdb8db929a7a.
* Revert "0.12.0"
  This reverts commit 27426b196eb0f88ce26fecd52b0d07211b54071d.
* 0.12.0
* changelogs
* Fix rosapi get_action_servers (#429 <https://github.com/LCAS/rosbridge_suite/issues/429>)
  The currently used proxy.get_topics function does not exists and results in the following error: "AttributeError: 'module' object has no attribute 'get_topics'n"
  This change uses the existing get_topics_and_types method to get a list of topics.
* Contributors: Jørgen Borgesen, Marc Hanheide
```

## rosbridge_library

```
* changed maintainer
* Revert "changelogs"
  This reverts commit bfc023af331ee980c558858fb03cfdb8db929a7a.
* Revert "0.12.0"
  This reverts commit 27426b196eb0f88ce26fecd52b0d07211b54071d.
* 0.12.0
* changelogs
* Contributors: Marc Hanheide
```

## rosbridge_msgs

```
* changed maintainer
* Revert "changelogs"
  This reverts commit bfc023af331ee980c558858fb03cfdb8db929a7a.
* Revert "0.12.0"
  This reverts commit 27426b196eb0f88ce26fecd52b0d07211b54071d.
* 0.12.0
* changelogs
* Contributors: Marc Hanheide
```

## rosbridge_server

```
* changed maintainer
* Revert "changelogs"
  This reverts commit bfc023af331ee980c558858fb03cfdb8db929a7a.
* Revert "0.12.0"
  This reverts commit 27426b196eb0f88ce26fecd52b0d07211b54071d.
* 0.12.0
* changelogs
* Autobahn WebSocket server (#426 <https://github.com/LCAS/rosbridge_suite/issues/426>)
  * Autobahn WebSocket server
  * Bring back explicit Twisted dependency
  Still used directly by the UDP handler.
  * Warn when reactor wasn't running at shutdown hook
  * More descriptive websocket startup log msg
  * Remove extreneous OutgoingValve stop log
  * More comment for OutgoingValve
  * Fix --address parsing as int
  * Use Autobahn's ws url creation util method
  * Backwards compatibility for empty websocket addr
  This was the default in previous versions, but invalid input to
  Autobahn.
  * Factor out websocket onConnect
  We have access to this information in onOpen.
  * Add smoke test for rosbridge websocket server
  * Revert "Use Autobahn's ws url creation util method"
  This reverts commit 4224671528a03875847918ae7164e672c4ba5fce.
  This create_url method doesn't exist yet in Ubuntu kinetic.
  * Preserve RosbridgeWebSocket Tornado ABI
  * Run rosbridge_websocket tests with ephemeral port
  Avoid network collisions and unnecessary configuration while testing.
  * Fix broken test create_url on kinetic
  * Smokier smoke test
  Send 100 large messages in each direction to saturate buffers.
* Contributors: Marc Hanheide, Matt Vollrath
```

## rosbridge_suite

```
* changed maintainer
* Revert "changelogs"
  This reverts commit bfc023af331ee980c558858fb03cfdb8db929a7a.
* Revert "0.12.0"
  This reverts commit 27426b196eb0f88ce26fecd52b0d07211b54071d.
* 0.12.0
* changelogs
* Contributors: Marc Hanheide
```
