### PR TITLE
uol_cmp9767m: 0.4.3-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1324,7 +1324,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/CMP9767M.git
-      version: 0.4.2-1
+      version: 0.4.3-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `uol_cmp9767m` to `0.4.3-1`:

- upstream repository: https://github.com/LCAS/CMP9767M.git
- release repository: https://github.com/lcas-releases/CMP9767M.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.8.0`
- previous version for package: `0.4.2-1`

## uol_cmp9767m_base

```
* Assmnt1920 (#41 <https://github.com/LCAS/CMP9767M/issues/41>)
  * new cropweed models
  * fixed texture height
* Contributors: gcielniak
```

## uol_cmp9767m_tutorial

- No changes
