### PR TITLE
thorvald: 1.2.1-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1217,7 +1217,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/thorvald-releases.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `1.2.1-1`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/LCAS/thorvald-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.2.0-1`

## thorvald

- No changes

## thorvald_2dnav

- No changes

## thorvald_base

- No changes

## thorvald_bringup

- No changes

## thorvald_can_devices

- No changes

## thorvald_description

```
* Inertia (#85 <https://github.com/LCAS/Thorvald/issues/85>)
  * Correct Inertia values for all links [HARDCODED]
  * Macro for calculating inertia on the fly
  * Code formatting
* Correct Inertia values for all links with xacro macro (#84 <https://github.com/LCAS/Thorvald/issues/84>)
  * Correct Inertia values for all links [HARDCODED]
  * Macro for calculating inertia on the fly
* Contributors: Riccardo Polvara
```

## thorvald_example_robots

- No changes

## thorvald_gazebo_plugins

- No changes

## thorvald_gui

- No changes

## thorvald_msgs

- No changes

## thorvald_simulator

- No changes

## thorvald_teleop

- No changes

## thorvald_twist_mux

- No changes
