### PR TITLE
velodyne_oru: 1.5.5-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1348,14 +1348,11 @@ repositories:
   velodyne_oru:
     release:
       packages:
-      - velodyne
-      - velodyne_driver
-      - velodyne_msgs
-      - velodyne_pointcloud
+      - velodyne_pointcloud_oru
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/velodyne-release.git
-      version: 1.2.1-0
+      version: 1.5.5-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_oru` to `1.5.5-1`:

- upstream repository: https://github.com/dan11003/velodyne_pointcloud_oru
- release repository: https://github.com/LCAS/velodyne-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.2.1-0`

## velodyne_pointcloud_oru

```
* Update cloud_node_vlp16_hz.test
  reduced minimum frequency required.
* Update cloud_nodelet_32e_hz.test
  reduced minimum frequency requirement for unit test
* updated tests
* updated name in unit tests
* Contributors: dan11003, daniel
```
