### PR TITLE
ndt_core: 2.3.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -446,7 +446,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/ndt_core-release.git
-      version: 2.0.0-0
+      version: 2.3.0-1
     source:
       type: git
       url: https://gitsvn-nt.oru.se/software/ndt_core.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ndt_core` to `2.3.0-1`:

- upstream repository: https://gitsvn-nt.oru.se/software/ndt_core.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/ndt_core-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.0.0-0`
