### PR TITLE
ndt_tools: 2.0.2-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -463,7 +463,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/ndt_tools-release.git
-      version: 2.0.0-0
+      version: 2.0.2-1
     source:
       type: git
       url: https://gitsvn-nt.oru.se/software/ndt_tools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ndt_tools` to `2.0.2-1`:

- upstream repository: https://gitsvn-nt.oru.se/software/ndt_tools.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/ndt_tools-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.0.0-0`

## ndt_feature_finder

- No changes

## ndt_fuser

- No changes

## ndt_localization

- No changes

## ndt_offline

- No changes

## ndt_tools

- No changes
