### PR TITLE
thorvald: 1.3.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -64,6 +64,25 @@ repositories:
       version: master
     status: developed
   thorvald:
+    release:
+      packages:
+      - thorvald
+      - thorvald_2dnav
+      - thorvald_base
+      - thorvald_bringup
+      - thorvald_can_devices
+      - thorvald_description
+      - thorvald_example_robots
+      - thorvald_gazebo_plugins
+      - thorvald_gui
+      - thorvald_msgs
+      - thorvald_simulator
+      - thorvald_teleop
+      - thorvald_twist_mux
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/LCAS/thorvald-releases.git
+      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `1.3.0-1`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/LCAS/thorvald-releases.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## thorvald

- No changes

## thorvald_2dnav

- No changes

## thorvald_base

- No changes

## thorvald_bringup

```
* changed gazebo for melodic
* Contributors: Marc Hanheide
```

## thorvald_can_devices

- No changes

## thorvald_description

```
* changed gazebo for melodic
* Contributors: Marc Hanheide
```

## thorvald_example_robots

- No changes

## thorvald_gazebo_plugins

```
* making code base the same for kinetic and melodic (#89 <https://github.com/LCAS/Thorvald/issues/89>)
* removed old gazebo plugin and adaptation for gazebo9+ (#87 <https://github.com/LCAS/Thorvald/issues/87>)
* changed gazebo for melodic
* Contributors: Marc Hanheide
```

## thorvald_gui

- No changes

## thorvald_msgs

- No changes

## thorvald_simulator

- No changes

## thorvald_teleop

- No changes

## thorvald_twist_mux

- No changes
