### PR TITLE
rosduct: 0.0.6-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -27,6 +27,11 @@ repositories:
       version: master
     status: maintained
   rosduct:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/rosduct.git
+      version: 0.0.6-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosduct` to `0.0.6-1`:

- upstream repository: https://github.com/LCAS/rosduct.git
- release repository: https://github.com/lcas-releases/rosduct.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## rosduct

```
* Fix: ROSDuctConnection() object's latch attribute not set (#5 <https://github.com/LCAS/rosduct/issues/5>)
  * Fix for missing latch for local and remote topics - in ROSDuctConnection objects
  Setting the default value of msg.latch for local and remote topics to False
  If the latch value is given in the config (takes up to 4 values for topics), that value is taken
  * msg.latch takes string or bool values for local and remote topics
  Fix in check_if_msgs_are_installed() when local_topics remote_topics has 4 fields
* Contributors: Gautham P Das
```
