### PR TITLE
bayes_tracking: 1.4.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -13,6 +13,11 @@ repositories:
       version: stable
     status: maintained
   bayes_tracking:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/bayestracking.git
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bayes_tracking` to `1.4.0-1`:

- upstream repository: https://github.com/LCAS/bayestracking.git
- release repository: https://github.com/lcas-releases/bayestracking.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## bayes_tracking

```
* added pruneNamedTracks (#25 <https://github.com/LCAS/bayestracking/issues/25>)
  * fixed tag check for LABELED
  * added pruneNamedTracks
  * removed print
  * pruning now works
* Contributors: Marc Hanheide
```
