### PR TITLE
realsense_ros: 2.3.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -75,6 +75,14 @@ repositories:
       version: develop
     status: developed
   realsense_ros:
+    release:
+      packages:
+      - ddynamic_reconfigure
+      - realsense2_camera
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/realsense.git
+      version: 2.3.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_ros` to `2.3.0-1`:

- upstream repository: https://github.com/LCAS/realsense.git
- release repository: https://github.com/lcas-releases/realsense.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## ddynamic_reconfigure

```
* disable testing
* Contributors: Marc Hanheide
```

## realsense2_camera

```
* Update package.xml
* Update CMakeLists.txt
* Contributors: Marc Hanheide
```
