### PR TITLE
realsense_ros: 2.3.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -669,7 +669,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/realsense.git
-      version: 2.2.6-3
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_ros` to `2.3.0-1`:

- upstream repository: https://github.com/LCAS/realsense.git
- release repository: https://github.com/lcas-releases/realsense.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `2.2.6-3`

## ddynamic_reconfigure

```
* disable testing
* Contributors: Marc Hanheide
```

## realsense2_camera

```
* Update package.xml
* Update CMakeLists.txt
* Contributors: Marc Hanheide
```
