### PR TITLE
robot_pose_publisher: 0.2.4-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -90,6 +90,13 @@ repositories:
       url: https://github.com/LCAS/realsense.git
       version: development
     status: maintained
+  robot_pose_publisher:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/robot_pose_publiser.git
+      version: 0.2.4-1
+    status: maintained
   rosduct:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `robot_pose_publisher` to `0.2.4-1`:

- upstream repository: https://github.com/GT-RAIL/robot_pose_publisher.git
- release repository: https://github.com/lcas-releases/robot_pose_publiser.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## robot_pose_publisher

```
* Update README.md
* Update package.xml
* fixed dox file
* fixed readme
* travis edit
* Contributors: David Kent, Russell Toris
```
