### PR TITLE
scitos_common: 0.1.12-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -142,6 +142,15 @@ repositories:
       version: master
     status: developed
   scitos_common:
+    release:
+      packages:
+      - scitos_common
+      - scitos_description
+      - scitos_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/strands-project-releases/scitos_common.git
+      version: 0.1.12-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_common` to `0.1.12-1`:

- upstream repository: https://github.com/strands-project/scitos_common.git
- release repository: https://github.com/strands-project-releases/scitos_common.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## scitos_common

- No changes

## scitos_description

- No changes

## scitos_msgs

- No changes
