### PR TITLE
velodyne_oru: 1.5.5-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -245,6 +245,13 @@ repositories:
       version: indigo-devel
     status: maintained
   velodyne_oru:
+    release:
+      packages:
+      - velodyne_pointcloud_oru
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/LCAS/velodyne-release.git
+      version: 1.5.5-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_oru` to `1.5.5-1`:

- upstream repository: https://github.com/dan11003/velodyne_pointcloud_oru
- release repository: https://github.com/LCAS/velodyne-release.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## velodyne_pointcloud_oru

```
* Update cloud_node_vlp16_hz.test
  reduced minimum frequency required.
* Update cloud_nodelet_32e_hz.test
  reduced minimum frequency requirement for unit test
* updated tests
* updated name in unit tests
* Contributors: dan11003, daniel
```
