### PR TITLE
steering_functions: 1.0.5-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -197,6 +197,11 @@ repositories:
       version: master
     status: developed
   steering_functions:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/steering_functions.git
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/iliad-project/steering_functions.git


### PR DESCRIPTION
Increasing version of package(s) in repository `steering_functions` to `1.0.5-1`:

- upstream repository: https://github.com/iliad-project/steering_functions.git
- release repository: https://github.com/lcas-releases/steering_functions.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## steering_functions

```
* install everything in headers
* Contributors: Marc Hanheide
```
