### PR TITLE
sentor: 2.0.3-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -159,6 +159,11 @@ repositories:
       version: indigo-devel
     status: maintained
   sentor:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/sentor.git
+      version: 2.0.3-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `sentor` to `2.0.3-1`:

- upstream repository: https://github.com/LCAS/sentor.git
- release repository: https://github.com/lcas-releases/sentor.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## sentor

```
* Merge pull request #3 <https://github.com/LCAS/sentor/issues/3> from francescodelduchetto/master
  fix some bugs
* Merge branch 'master' into master
* Merge branch 'master' of https://github.com/francescodelduchetto/sentor
* fix various errors
* Contributors: Lindsey User, Marc Hanheide
```
