### PR TITLE
persistent_topics: 1.5.2-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -83,6 +83,11 @@ repositories:
       version: master
     status: maintained
   persistent_topics:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/persistent_topics.git
+      version: 1.5.2-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `persistent_topics` to `1.5.2-1`:

- upstream repository: https://github.com/marc-hanheide/persistent_topics.git
- release repository: https://github.com/lcas-releases/persistent_topics.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## persistent_topics

- No changes
