### PR TITLE
marvelmind_nav_lcas: 1.0.9-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -75,6 +75,13 @@ repositories:
       version: master
     status: maintained
   marvelmind_nav_lcas:
+    release:
+      packages:
+      - marvelmind_nav
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/ros_marvelmind_package.git
+      version: 1.0.9-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `marvelmind_nav_lcas` to `1.0.9-1`:

- upstream repository: https://github.com/LCAS/ros_marvelmind_package.git
- release repository: https://github.com/lcas-releases/ros_marvelmind_package.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## marvelmind_nav

```
* ROS_INFOs along with topic publish are disabled
* changed maintainer
* added install targets
* Contributors: Marc Hanheide, gpdas, thorvald
```
