### PR TITLE
uol_cmp9767m: 0.5.2-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1372,7 +1372,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/CMP9767M.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `uol_cmp9767m` to `0.5.2-1`:

- upstream repository: https://github.com/LCAS/CMP9767M.git
- release repository: https://github.com/lcas-releases/CMP9767M.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.5.1-1`

## uol_cmp9767m_base

```
* Merge branch 'master' into mapping
* Contributors: gcielniak
```

## uol_cmp9767m_tutorial

```
* Merge pull request #44 <https://github.com/LCAS/CMP9767M/issues/44> from LCAS/mapping
  Additional files for workshop 8. AMCL launch can now accept robot_name as a parameter.
* Merge branch 'master' into mapping
* Additional files for workshop 8. AMCL launch can now accept robot_name as a parameter.
* Merge pull request #43 <https://github.com/LCAS/CMP9767M/issues/43> from LCAS/w7_1920
  space fix planners
* space fix planners
* warning fix in planners config
* Contributors: Grzegorz Cielniak, gcielniak
```
