### PR TITLE
strands_ui: 0.2.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -230,6 +230,20 @@ repositories:
       version: iliad
     status: maintained
   strands_ui:
+    release:
+      packages:
+      - mary_tts
+      - mongodb_media_server
+      - music_player
+      - pygame_managed_player
+      - robot_talk
+      - sound_player_server
+      - strands_ui
+      - strands_webserver
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_ui.git
+      version: 0.2.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_ui` to `0.2.1-1`:

- upstream repository: https://github.com/strands-project/strands_ui.git
- release repository: https://github.com/strands-project-releases/strands_ui.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## mary_tts

```
* Merge pull request #109 <https://github.com/strands-project/strands_ui/issues/109> from francescodelduchetto/pull-req
  fix global variable declaration missing
* fix global variable declaration missing
* Contributors: Marc Hanheide, francescodelduchetto
```

## mongodb_media_server

- No changes

## music_player

- No changes

## pygame_managed_player

- No changes

## robot_talk

- No changes

## sound_player_server

- No changes

## strands_ui

- No changes

## strands_webserver

- No changes
