### PR TITLE
scitos_drivers: 0.2.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -179,6 +179,17 @@ repositories:
       version: indigo-devel
     status: maintained
   scitos_drivers:
+    release:
+      packages:
+      - flir_pantilt_d46
+      - scitos_bringup
+      - scitos_drivers
+      - scitos_mira
+      - scitos_pc_monitor
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/strands-project-releases/scitos_drivers.git
+      version: 0.2.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_drivers` to `0.2.0-1`:

- upstream repository: https://github.com/strands-project/scitos_drivers.git
- release repository: https://github.com/strands-project-releases/scitos_drivers.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## flir_pantilt_d46

```
* changelogs
* changed maintainer from Chris to Marc
* Contributors: Marc Hanheide
* changed maintainer from Chris to Marc
* Contributors: Marc Hanheide
```

## scitos_bringup

```
* removed odometry_mileage as it caused a cyclic dependency
* changelogs
* Contributors: Marc Hanheide
```

## scitos_drivers

```
* changelogs
* changed maintainer from Chris to Marc
* Contributors: Marc Hanheide
* changed maintainer from Chris to Marc
* Contributors: Marc Hanheide
```

## scitos_mira

```
* added qt4 dep
* changelogs
* changed maintainer from Chris to Marc
* modifications required for new MIRA and Kinetic, plus setting MIRA_PATH from setup.bash
* MotorReset enabled
  fixes https://github.com/strands-project/scitos_robot/issues/77
* Contributors: Marc Hanheide
* changed maintainer from Chris to Marc
* modifications required for new MIRA and Kinetic, plus setting MIRA_PATH from setup.bash
* MotorReset enabled
  fixes https://github.com/strands-project/scitos_robot/issues/77
* Contributors: Marc Hanheide
```

## scitos_pc_monitor

```
* changelogs
* changed maintainer from Chris to Marc
* Contributors: Marc Hanheide
* changed maintainer from Chris to Marc
* Contributors: Marc Hanheide
```
