### PR TITLE
whycon: 2.3.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -379,7 +379,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/strands-project-releases/whycon.git
-      version: 0.2.4-1
+      version: 2.3.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `whycon` to `2.3.0-1`:

- upstream repository: https://github.com/LCAS/whycon.git
- release repository: https://github.com/strands-project-releases/whycon.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.4-1`

## whycon_ros

```
* 0.2.4
* changelog
* fixed dependencies
* added id generator
* imported snapcart version
* Contributors: Marc Hanheide
```
