### PR TITLE
whycon: 2.3.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1419,6 +1419,13 @@ repositories:
       version: gazebo8
     status: maintained
   whycon:
+    release:
+      packages:
+      - whycon_ros
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/strands-project-releases/whycon.git
+      version: 2.3.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `whycon` to `2.3.0-1`:

- upstream repository: https://github.com/LCAS/whycon.git
- release repository: https://github.com/strands-project-releases/whycon.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## whycon_ros

```
* 0.2.4
* changelog
* fixed dependencies
* added id generator
* imported snapcart version
* Contributors: Marc Hanheide
```
