### PR TITLE
libfreenect2: 0.1.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -67,6 +67,11 @@ repositories:
       version: master
     status: developed
   libfreenect2:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/libfreenect2.git
+      version: 0.1.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `libfreenect2` to `0.1.0-1`:

- upstream repository: https://github.com/LCAS/libfreenect2.git
- release repository: https://github.com/lcas-releases/libfreenect2.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## libfreenect2

```
* Merge pull request #3 <https://github.com/LCAS/libfreenect2/issues/3> from LCAS/new
  Pulled upstream and made more general for cuda
* Fixed cuda
* new cuda
* Merge branch 'master' of https://github.com/OpenKinect/libfreenect2 into new
* Update TegraJPEG detection
  Use jpeglib.h from /usr/src/tegra_multimedia_api.
  Remove old source downloading and Tegra version detection routines.
  Remove support for 32-bit platforms (probably TK1).
* Add android build script and instructions (#1060 <https://github.com/LCAS/libfreenect2/issues/1060>)
* Add setting of LEDs (#1052 <https://github.com/LCAS/libfreenect2/issues/1052>)
* docs: Remove homebrew/versions from instructions
  homebrew-core is the default formulae barrel, so no need to tap.
* Fix contructor usage in C++98
* Add exposure control of the color camera
* Contributors: CismonX, David da Silva, Lingzhu Xiang, Marc Hanheide, Saul Thurrowgood
```
