### PR TITLE
openni_wrapper: 0.1.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -111,6 +111,11 @@ repositories:
       version: master
     status: maintained
   openni_wrapper:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/strands-project-releases/openni_wrapper.git
+      version: 0.1.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_wrapper` to `0.1.0-1`:

- upstream repository: https://github.com/strands-project/openni_wrapper.git
- release repository: https://github.com/strands-project-releases/openni_wrapper.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## openni_wrapper

```
* new export class
* Contributors: Marc Hanheide
```
