### PR TITLE
iai_kinect2: 0.0.9-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -68,6 +68,17 @@ repositories:
       version: master
     status: developed
   iai_kinect2:
+    release:
+      packages:
+      - iai_kinect2
+      - kinect2_bridge
+      - kinect2_calibration
+      - kinect2_registration
+      - kinect2_viewer
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/iai_kinect2.git
+      version: 0.0.9-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `iai_kinect2` to `0.0.9-1`:

- upstream repository: https://github.com/LCAS/iai_kinect2.git
- release repository: https://github.com/lcas-releases/iai_kinect2.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## iai_kinect2

- No changes

## kinect2_bridge

```
* Changed readme.md file in kinect2_bridge
* Contributors: Manuel Fernandez-Carmona
```

## kinect2_calibration

- No changes

## kinect2_registration

- No changes

## kinect2_viewer

- No changes
