### PR TITLE
strands_apps: 0.2.6-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -287,6 +287,26 @@ repositories:
       version: iliad
     status: maintained
   strands_apps:
+    release:
+      packages:
+      - door_pass
+      - marathon_reporter
+      - odometry_mileage
+      - pose_extractor
+      - ramp_climb
+      - reconfigure_inflation
+      - roslaunch_axserver
+      - state_checker
+      - static_transform_manager
+      - strands_apps
+      - strands_emails
+      - topic_republisher
+      - topological_roslaunch
+      - watchdog_node
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_apps.git
+      version: 0.2.6-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.2.6-1`:

- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## door_pass

```
* always check door before passing
* display arrow while waiting
* updates to use door waiting properly
* reduce required time of seeing the door open for the glass door.
* less confident on open doors when doing door_wait_and_move_base as this action is to be used for glass doors
* Fixing bug when no doors in the environment (#64 <https://github.com/strands-project/strands_apps/issues/64>)
  * adding door prediction to install targets
  * fixing bug when no doors in the environment
* Contributors: Bruno Lacerda, Jaime Pulido Fentanes
```

## marathon_reporter

```
* using system's requests
* Contributors: Marc Hanheide
```

## odometry_mileage

- No changes

## pose_extractor

- No changes

## ramp_climb

- No changes

## reconfigure_inflation

- No changes

## roslaunch_axserver

- No changes

## state_checker

- No changes

## static_transform_manager

- No changes

## strands_apps

- No changes

## strands_emails

- No changes

## topic_republisher

- No changes

## topological_roslaunch

```
* Add warning when no launch information received
* Improve teardown/bringup mechanics
  Can now bring up launch files at a set of nodes, in the same way as with the
  teardown.
  The two classes used to do the launching now have a base class to reduce code
  duplication.
* Contributors: Michal Staniaszek
```

## watchdog_node

- No changes
