### PR TITLE
slackeros: 0.2.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -289,6 +289,11 @@ repositories:
       version: master
     status: maintained
   slackeros:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/slackeros.git
+      version: 0.2.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `slackeros` to `0.2.1-1`:

- upstream repository: https://github.com/marc-hanheide/slackeros.git
- release repository: https://github.com/lcas-releases/slackeros.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## slackeros

```
* Merge pull request #12 <https://github.com/marc-hanheide/slackeros/issues/12> from marc-hanheide/format_and_name
  Format and name
* identify author as hostname
* mostly formatting
* Contributors: Marc Hanheide
```
