### PR TITLE
iai_kinect2: 0.0.10-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -83,7 +83,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/iai_kinect2.git
-      version: 0.0.9-1
+      version: 0.0.10-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `iai_kinect2` to `0.0.10-1`:

- upstream repository: https://github.com/LCAS/iai_kinect2.git
- release repository: https://github.com/lcas-releases/iai_kinect2.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.9-1`

## iai_kinect2

- No changes

## kinect2_bridge

```
* added opencl dep
* Contributors: Marc Hanheide
```

## kinect2_calibration

- No changes

## kinect2_registration

```
* added opencl dep
* Contributors: Marc Hanheide
```

## kinect2_viewer

- No changes
