### PR TITLE
strands_movebase: 0.0.23-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -356,6 +356,18 @@ repositories:
       version: kinetic-devel
     status: maintained
   strands_movebase:
+    release:
+      packages:
+      - calibrate_chest
+      - movebase_state_service
+      - param_loader
+      - strands_description
+      - strands_movebase
+      - strands_navfn
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_movebase.git
+      version: 0.0.23-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_movebase` to `0.0.23-1`:

- upstream repository: https://github.com/strands-project/strands_movebase.git
- release repository: https://github.com/strands-project-releases/strands_movebase.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## calibrate_chest

- No changes

## movebase_state_service

- No changes

## param_loader

- No changes

## strands_description

- No changes

## strands_movebase

```
* Added proper install target for subsampling nodelet
* Contributors: Nils Bore
```

## strands_navfn

- No changes
