### PR TITLE
strands_movebase: 1.0.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -364,6 +364,17 @@ repositories:
       version: kinetic-devel
     status: maintained
   strands_movebase:
+    release:
+      packages:
+      - calibrate_chest
+      - movebase_state_service
+      - param_loader
+      - strands_description
+      - strands_movebase
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_movebase.git
+      version: 1.0.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_movebase` to `1.0.0-1`:

- upstream repository: https://github.com/strands-project/strands_movebase.git
- release repository: https://github.com/strands-project-releases/strands_movebase.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## calibrate_chest

- No changes

## movebase_state_service

- No changes

## param_loader

```
* Updated email to new Oxford address
* Contributors: Nick Hawes
```

## strands_description

- No changes

## strands_movebase

```
* Merge pull request #75 <https://github.com/strands-project/strands_movebase/issues/75> from strands-project/remove_strands_navfn
  removed strands_navfn
* removed strands_navfn
* Contributors: Marc Hanheide
```
