### PR TITLE
lcas_morse: 1.4.2-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -99,6 +99,13 @@ repositories:
       version: master
     status: developed
   lcas_morse:
+    release:
+      packages:
+      - morse
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/morse.git
+      version: 1.4.2-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `lcas_morse` to `1.4.2-1`:

- upstream repository: https://github.com/strands-project/morse.git
- release repository: https://github.com/lcas-releases/morse.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
