### PR TITLE
strands_morse: 0.2.3-2 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -375,7 +375,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.2.3-1
+      version: 0.2.3-2
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.2.3-2`:

- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.3-1`

## strands_morse

```
* Merge pull request #175 <https://github.com/strands-project/strands_morse/issues/175> from francescodelduchetto/kinetic-devel
  the collection museum simulation
* simulation scaled according to real-world measures
* better lights for simulation
* the collection museum simulation
* Contributors: Marc Hanheide, francescodelduchetto
```
