### PR TITLE
strands_navigation: 1.1.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -403,6 +403,23 @@ repositories:
       version: melodic-devel
     status: developed
   strands_navigation:
+    release:
+      packages:
+      - emergency_behaviours
+      - joy_map_saver
+      - monitored_navigation
+      - nav_goals_generator
+      - pose_initialiser
+      - strands_navigation
+      - strands_navigation_msgs
+      - topological_logging_manager
+      - topological_navigation
+      - topological_rviz_tools
+      - topological_utils
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_navigation.git
+      version: 1.1.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `1.1.0-1`:

- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## emergency_behaviours

- No changes

## joy_map_saver

- No changes

## monitored_navigation

- No changes

## nav_goals_generator

- No changes

## pose_initialiser

- No changes

## strands_navigation

```
* Merge branch 'indigo-devel' into fix_route_search
* Merge pull request #376 <https://github.com/strands-project/strands_navigation/issues/376> from gpdas/exec_policy_reconf_edge
  enable edge_reconfig for execute_policy_mode server
* removing message_store_map_switcher from dependencies
* Contributors: Jaime Pulido Fentanes, gpdas
```

## strands_navigation_msgs

- No changes

## topological_logging_manager

- No changes

## topological_navigation

```
* Merge pull request #377 <https://github.com/strands-project/strands_navigation/issues/377> from gpdas/fix_route_search
  Fix route search
* variable name fix
* Merge branch 'indigo-devel' into fix_route_search
* Merge pull request #376 <https://github.com/strands-project/strands_navigation/issues/376> from gpdas/exec_policy_reconf_edge
  enable edge_reconfig for execute_policy_mode server
* fix TopologicalRouteSearch
  1. As of now, an expanded node (in expanded or to_expand) are not updated when a shorter path to it is found. This is fixed.
  2. Some performance improvements by limiting loop iterations searching for expanded_node
* TopologicalRouteSearch checks origin and target are the same
* enable edge_reconfig for execute_policy_mode server
  1. edge reconfig ported from topological_navigation/navigation.py
  2. minor fixes in
  - topological_navigation/navigation.py
  - topological_navigation/route_search.py
* Contributors: Jaime Pulido Fentanes, gpdas
```

## topological_rviz_tools

- No changes

## topological_utils

```
* scripts to add/remove tags to yaml topomaps (#381 <https://github.com/strands-project/strands_navigation/issues/381>)
  * scripts to add/remove tags to yaml topomaps
  usage:
  add_node_tags.py <in_yaml_topomap> out_yaml_topomap> <node-tag-config-yaml>
  remove_node_tags.py <in_yaml_topomap> out_yaml_topomap> <node-tag-config-yaml>
  takes a yaml formatted config file for node tags.
  example
  ```
  charging_node:
  - WayPoint10
  door_transitions:
  - WayPoint4
  - WayPoint5
  - WayPoint24
  - WayPoint25
  ```
  * bug fix and cleanup
* Merge pull request #380 <https://github.com/strands-project/strands_navigation/issues/380> from gpdas/plot_yaml_fix
  fixed remaining rospy references
* fixed remaining rospy references
* Merge pull request #379 <https://github.com/strands-project/strands_navigation/issues/379> from gpdas/plot_topo_map
  new script to plot topomaps from yaml files
* fix strip_str
  removes strip_str from node_name only if the full string is in the node_name
* removed ros dependency
* install target added for new script
* new script to plot topomaps from yaml files
  1. plot_yaml.py
  2. minor modification to plot_topo_map.py
* Contributors: Gautham P Das, Jaime Pulido Fentanes, gpdas
```
