### PR TITLE
py_at_broker: 0.0.4-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -669,6 +669,11 @@ repositories:
       version: catkinised
     status: developed
   py_at_broker:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/LCAS/py_at_broker-release.git
+      version: 0.0.4-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `py_at_broker` to `0.0.4-1`:

- upstream repository: https://github.com/LCAS/py_at_broker.git
- release repository: https://github.com/LCAS/py_at_broker-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## py_at_broker

```
* added package.xml and always compile realtime
* Merge pull request #2 <https://github.com/LCAS/py_at_broker/issues/2> from sarkrishnan/master
  added additional sensor message capability for sl_panda to python
* added additional sensor message capability for sl_panda to python
* Update readme.rst
  added description for compile parameters to py_at_broker build
* Update readme.rst
* Update readme.rst
* Merge pull request #1 <https://github.com/LCAS/py_at_broker/issues/1> from shyamashi/py_branch
  Py branch
* readme updated
* readme updated
* CMake Cache file should not be part of the repo
* Update readme.rst
* add missing cmake file
* deleted cache
* deleted cache
* first push
* Contributors: Aravinda Ramakrishnan Srinivasan, Ash Babu, Geri, GeriNeumann, Marc Hanheide, sarkrishnan
```
