### PR TITLE
py_at_broker: 0.0.5-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -172,7 +172,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/LCAS/py_at_broker-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `py_at_broker` to `0.0.5-1`:

- upstream repository: https://github.com/LCAS/py_at_broker.git
- release repository: https://github.com/LCAS/py_at_broker-release.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.4-1`

## py_at_broker

```
* export and install all headers correctly
* Contributors: Marc Hanheide
```
