### PR TITLE
py_at_broker: 0.0.8-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -172,7 +172,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/LCAS/py_at_broker-release.git
-      version: 0.0.5-1
+      version: 0.0.8-1
     source:
       test_commits: true
       test_pull_requests: true
@@ -323,6 +323,14 @@ repositories:
       url: https://github.com/strands-project/sicks300.git
       version: master
     status: maintained
+  sl_panda:
+    source:
+      test_commits: true
+      test_pull_requests: true
+      type: git
+      url: https://github.com/LCAS/sl.git
+      version: catkinised
+    status: developed
   slackeros:
     release:
       tags:
@@ -335,14 +343,6 @@ repositories:
       type: git
       url: https://github.com/marc-hanheide/slackeros.git
       version: master
-    status: developed
-  sl_panda:
-    source:
-      test_commits: true
-      test_pull_requests: true
-      type: git
-      url: https://github.com/LCAS/sl.git
-      version: catkinised
     status: developed
   snap_cart:
     source:


### PR DESCRIPTION
Increasing version of package(s) in repository `py_at_broker` to `0.0.8-1`:

- upstream repository: https://github.com/LCAS/py_at_broker.git
- release repository: https://github.com/LCAS/py_at_broker-release.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.5-1`

## py_at_broker

```
* lower python version ok
* Contributors: Marc Hanheide
```
