### PR TITLE
py_at_broker: 0.0.10-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -673,7 +673,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/py_at_broker-release.git
-      version: 0.0.9-1
+      version: 0.0.10-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `py_at_broker` to `0.0.10-1`:

- upstream repository: https://github.com/LCAS/py_at_broker.git
- release repository: https://github.com/LCAS/py_at_broker-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.0.9-1`

## py_at_broker

```
* added root
* Contributors: Marc Hanheide
```
