### PR TITLE
uol_cmp9767m: 0.5.3-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1401,7 +1401,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/CMP9767M.git
-      version: 0.5.2-1
+      version: 0.5.3-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `uol_cmp9767m` to `0.5.3-1`:

- upstream repository: https://github.com/LCAS/CMP9767M.git
- release repository: https://github.com/lcas-releases/CMP9767M.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.5.2-1`

## uol_cmp9767m_base

```
* disable actor collisions
* Contributors: Marc Hanheide
```

## uol_cmp9767m_tutorial

```
* Merge pull request #46 <https://github.com/LCAS/CMP9767M/issues/46> from gpdas/tutorial12_fixes
  Merging this. minor changes.
* remapping some topics
* Contributors: Gautham P Das, gpdas
```
