### PR TITLE
strands_perception_people: 1.9.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1147,7 +1147,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 1.8.1-1
+      version: 1.9.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `1.9.0-1`:

- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.8.1-1`

## bayes_people_tracker

```
* Merge pull request #226 <https://github.com/strands-project/strands_perception_people/issues/226> from semeyerz/people-check
  readd people to subscription check
* readd people to subscription check
* Contributors: Christian Dondrup, Sebastian M. z. Borgsen
```

## bayes_people_tracker_logging

- No changes

## detector_msg_to_pose_array

- No changes

## ground_plane_estimation

- No changes

## human_trajectory

- No changes

## mdl_people_tracker

- No changes

## odometry_to_motion_matrix

- No changes

## people_tracker_emulator

- No changes

## people_tracker_filter

```
* Frame_id fix (#228 <https://github.com/strands-project/strands_perception_people/issues/228>)
  * Added SPENCER topics to upper_body_detector
  * UN-spencerization
  * UN-spencerization 2
  * UN-spencerization 3
  * First draft using grid_map
  * Using same tf for all received points
  * Detached tf lookup from callback. Publication speeds are now comparable to original approach
* Contributors: Manuel Fernandez-Carmona
```

## perception_people_launch

- No changes

## rwth_upper_body_skeleton_random_walk

- No changes

## strands_perception_people

- No changes

## upper_body_detector

- No changes

## vision_people_logging

- No changes

## visual_odometry

- No changes
