### PR TITLE
lcas_teaching: 0.2.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -336,7 +336,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/lcas_teaching.git
-      version: 0.2.0-0
+      version: 0.2.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `lcas_teaching` to `0.2.0-1`:

- upstream repository: https://github.com/LCAS/teaching.git
- release repository: https://github.com/strands-project-releases/lcas_teaching.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.0-0`
