### PR TITLE
lcas_teaching: 1.0.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -336,7 +336,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/lcas_teaching.git
-      version: 0.2.0-0
+      version: 1.0.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `lcas_teaching` to `1.0.0-1`:

- upstream repository: https://github.com/LCAS/teaching.git
- release repository: https://github.com/strands-project-releases/lcas_teaching.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `0.2.0-0`

## uol_cmp3103m

- No changes

## uol_rpi_tbot

```
* added blockly
* fixed re
* added server files
* Contributors: Marc Hanheide
```

## uol_turtlebot_common

- No changes

## uol_turtlebot_simulator

```
* working towards new assessment with maze (#34 <https://github.com/LCAS/teaching/issues/34>)
  * added gzmaze editor
  * updated gzmaze
  * added build_depends
  * simple lanuch and maze world
  * changes for week 1 tutoral
  * correct collisions
* Merge pull request #33 <https://github.com/LCAS/teaching/issues/33> from paul-baxter/kinetic
* minor position change for cylinder A (red)
* change target positions for 18-19 assessment
* removed outdated materials
* Contributors: Marc Hanheide, Paul Baxter, paul-baxter
```
