### PR TITLE
lcas_teaching: 1.0.2-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -336,7 +336,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/lcas_teaching.git
-      version: 1.0.1-1
+      version: 1.0.2-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `lcas_teaching` to `1.0.2-1`:

- upstream repository: https://github.com/LCAS/teaching.git
- release repository: https://github.com/strands-project-releases/lcas_teaching.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.0.1-1`

## uol_cmp3103m

- No changes

## uol_rpi_tbot

- No changes

## uol_turtlebot_common

- No changes

## uol_turtlebot_simulator

```
* gzmaze fixes and better default camera and light
* Contributors: Marc Hanheide
```
