### PR TITLE
strands_perception_people: 1.10.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -485,6 +485,26 @@ repositories:
       version: indigo-devel
     status: developed
   strands_perception_people:
+    release:
+      packages:
+      - bayes_people_tracker
+      - bayes_people_tracker_logging
+      - detector_msg_to_pose_array
+      - ground_plane_estimation
+      - human_trajectory
+      - mdl_people_tracker
+      - odometry_to_motion_matrix
+      - people_tracker_emulator
+      - people_tracker_filter
+      - perception_people_launch
+      - strands_perception_people
+      - upper_body_detector
+      - vision_people_logging
+      - visual_odometry
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_perception_people.git
+      version: 1.10.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `1.10.0-1`:

- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## bayes_people_tracker

- No changes

## bayes_people_tracker_logging

- No changes

## detector_msg_to_pose_array

- No changes

## ground_plane_estimation

- No changes

## human_trajectory

- No changes

## mdl_people_tracker

- No changes

## odometry_to_motion_matrix

- No changes

## people_tracker_emulator

- No changes

## people_tracker_filter

- No changes

## perception_people_launch

- No changes

## strands_perception_people

- No changes

## upper_body_detector

- No changes

## vision_people_logging

- No changes

## visual_odometry

- No changes
