### PR TITLE
strands_executive: 1.2.5-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -437,6 +437,19 @@ repositories:
       version: kinetic-devel
     status: maintained
   strands_executive:
+    release:
+      packages:
+      - gcal_routine
+      - mdp_plan_exec
+      - prism_strands
+      - sim_clock
+      - strands_executive_msgs
+      - task_executor
+      - wait_action
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_executive.git
+      version: 1.2.5-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `1.2.5-1`:

- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## gcal_routine

```
* Merge pull request #311 <https://github.com/strands-project/strands_executive/issues/311> from strands-project/ori-kinetic-devel
  Merges in ORI developments from elsewhere
* Merge remote-tracking branch 'ori/kinetic-devel' into working-kinetic-devel
  Adding in ori developments from last few months.
* Merge branch 'kinetic-devel' of https://github.com/strands-project/strands_executive into kinetic-devel
* big code clean: remove old (simplified) mdp nodes and scheduler.
* Contributors: Bruno Lacerda, Nick Hawes
```

## mdp_plan_exec

```
* Merge pull request #319 <https://github.com/strands-project/strands_executive/issues/319> from bfalacerda/kinetic-devel
  re-add logic for nav_before_action_exec param
* re-add logic for nav_before_action_exec param
* Merge pull request #315 <https://github.com/strands-project/strands_executive/issues/315> from bfalacerda/kinetic-devel
  ensuring edge prediction is called first time the mdp action server receives a goal
* call prediction for first time it is called
* Merge pull request #314 <https://github.com/strands-project/strands_executive/issues/314> from bfalacerda/kinetic-devel
  memorise previous predictions
* memorise previous predictions
* added parameters for modelling back in to mdp executor
* Merge pull request #311 <https://github.com/strands-project/strands_executive/issues/311> from strands-project/ori-kinetic-devel
  Merges in ORI developments from elsewhere
* Added door params to launch files
* Merge remote-tracking branch 'ori/kinetic-devel' into working-kinetic-devel
  Adding in ori developments from last few months.
* Merge pull request #308 <https://github.com/strands-project/strands_executive/issues/308> from bfalacerda/kinetic-devel
  namespace sorting and params to adapt door and action exec behaviour
* params to ignore door configs and execute actions on the spot
* Merge branch 'kinetic-devel' of https://github.com/strands-project/strands_executive into kinetic-devel
* Update CMakeLists.txt
* code cleanup
* bug fix
* Merge branch 'kinetic-devel' of bitbucket.org:oxfordroboticsinstitute/strands_executive into kinetic-devel
* stop redundant predictions
* correcting small bugs with preemption
* big code clean: remove old (simplified) mdp nodes and scheduler.
* update guarantees estmator node to use new policy utils class; more cleaning
* cleaning code; executor now fully tested with new policy utils class
* more refactoring
* code refactoring to allow simulation
* logging specific navigation statistics
* logging mdp execution - task level
* remove import added by mistake
* correct action server feedback
* re-add mr launch file to ensure each robot has its own prism dir
* remove mr launch file
* changes for multi-robot
* making topic names relative to use namespaces for multi-robot setup
* Contributors: Bruno Lacerda, Nick Hawes
```

## prism_strands

```
* Merge pull request #313 <https://github.com/strands-project/strands_executive/issues/313> from bfalacerda/kinetic-devel
  prism update
* prism update
* Merge pull request #311 <https://github.com/strands-project/strands_executive/issues/311> from strands-project/ori-kinetic-devel
  Merges in ORI developments from elsewhere
* Merge remote-tracking branch 'ori/kinetic-devel' into working-kinetic-devel
  Adding in ori developments from last few months.
* Merge branch 'kinetic-devel' of https://github.com/strands-project/strands_executive into kinetic-devel
* Merge branch 'kinetic-devel' of bitbucket.org:oxfordroboticsinstitute/strands_executive into kinetic-devel
* updating prism version to install
* Merge branch 'kinetic-devel' of https://github.com/strands-project/strands_executive into kinetic-devel
* Contributors: Bruno Lacerda, Nick Hawes
```

## sim_clock

```
* Merge branch 'kinetic-devel' of https://github.com/strands-project/strands_executive into kinetic-devel
* Contributors: Bruno Lacerda
```

## strands_executive_msgs

```
* Merge pull request #311 <https://github.com/strands-project/strands_executive/issues/311> from strands-project/ori-kinetic-devel
  Merges in ORI developments from elsewhere
* Merge remote-tracking branch 'ori/kinetic-devel' into working-kinetic-devel
  Adding in ori developments from last few months.
* Merge pull request #309 <https://github.com/strands-project/strands_executive/issues/309> from francescodelduchetto/pull-req
  Add GetBlacklistedNodes srv
* Add GetBlacklistedNodes srv
* Merge branch 'kinetic-devel' of https://github.com/strands-project/strands_executive into kinetic-devel
* more general argument addition for actions
* big code clean: remove old (simplified) mdp nodes and scheduler.
* logging specific navigation statistics
* logging mdp execution - task level
* Contributors: Bruno Lacerda, Nick Hawes, francescodelduchetto
```

## task_executor

```
* Merge pull request #317 <https://github.com/strands-project/strands_executive/issues/317> from strands-project/fix-316
  Removing buggy code for closing task windows during execution.
* Removing buggy code for closing task windows during execution.
  This closes #316 <https://github.com/strands-project/strands_executive/issues/316>
* removing absolute namespace from battery topic
* Merge pull request #311 <https://github.com/strands-project/strands_executive/issues/311> from strands-project/ori-kinetic-devel
  Merges in ORI developments from elsewhere
* Blacklist nodes are now excluded from policy execution using the LTL spec.
* Blacklisted nodes are included as part of MDP LTL spec
* Merge remote-tracking branch 'ori/kinetic-devel' into working-kinetic-devel
  Adding in ori developments from last few months.
* Merge pull request #308 <https://github.com/strands-project/strands_executive/issues/308> from bfalacerda/kinetic-devel
  namespace sorting and params to adapt door and action exec behaviour
* params to ignore door configs and execute actions on the spot
* Merge branch 'kinetic-devel' of https://github.com/strands-project/strands_executive into kinetic-devel
* Added sim_time default value
* Added more policy information into the schedule output
* Added default for parameter
* more namespace updates
* edits for namespaces
* big code clean: remove old (simplified) mdp nodes and scheduler.
* remove uneeded multi robot launch file - one cane use ROS_NAMESPACE=ns instead
* Merge branch 'kinetic-devel' of https://bitbucket.org/oxfordroboticsinstitute/strands_executive into kinetic-devel
* changes for multi-robot
* More informative log message.
* Publishing execution status for easier interaction
* Merge branch 'kinetic-devel' of https://github.com/strands-project/strands_executive into kinetic-devel
* Contributors: Bruno Lacerda, Nick Hawes
```

## wait_action

```
* Merge branch 'kinetic-devel' of https://github.com/strands-project/strands_executive into kinetic-devel
* Contributors: Bruno Lacerda
```
