### PR TITLE
gazebo_contact_monitor: 1.2.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -73,6 +73,13 @@ repositories:
       version: master
     status: developed
   gazebo_contact_monitor:
+    release:
+      packages:
+      - contact_monitor
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/gazebo-contactMonitor.git
+      version: 1.2.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_contact_monitor` to `1.2.0-1`:

- upstream repository: https://github.com/LCAS/gazebo-contactMonitor.git
- release repository: https://github.com/lcas-releases/gazebo-contactMonitor.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## contact_monitor

```
* Merge pull request #3 <https://github.com/LCAS/gazebo-contactMonitor/issues/3> from gpdas/melodic-devel
  gazebo8-* -> gazebo-*
* gazebo8-* -> gazebo-*
* Corrected wrong param name. Added params as args.
* Contributors: Gautham P Das, Manuel Fernandez-Carmona, gpdas
```
