### PR TITLE
gazebo_contact_monitor: 1.2.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -79,7 +79,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/gazebo-contactMonitor.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `gazebo_contact_monitor` to `1.2.1-1`:

- upstream repository: https://github.com/LCAS/gazebo-contactMonitor.git
- release repository: https://github.com/lcas-releases/gazebo-contactMonitor.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.1`
- previous version for package: `1.2.0-1`

## contact_monitor

```
* typo (#4 <https://github.com/LCAS/gazebo-contactMonitor/issues/4>)
  * typo
  * gazebo_ros
* proper flags for gazebo
* Contributors: Gautham P Das, Marc Hanheide
```
