### PR TITLE
franka_ros_lcas: 0.8.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -52,6 +52,20 @@ repositories:
       version: master
     status: maintained
   franka_ros_lcas:
+    release:
+      packages:
+      - franka_control
+      - franka_description
+      - franka_example_controllers
+      - franka_gripper
+      - franka_hw
+      - franka_msgs
+      - franka_ros
+      - franka_visualization
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/franka_ros.git
+      version: 0.8.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `franka_ros_lcas` to `0.8.0-1`:

- upstream repository: https://github.com/LCAS/franka_ros.git
- release repository: https://github.com/lcas-releases/franka_ros.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
