### PR TITLE
saga_agrinav: 0.0.2-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -330,6 +330,13 @@ repositories:
       version: master
     status: developed
   saga_agrinav:
+    release:
+      packages:
+      - polytunnel_navigation_actions
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/SAGARobotics/AgriNav-release.git
+      version: 0.0.2-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `saga_agrinav` to `0.0.2-1`:

- upstream repository: https://github.com/SAGARobotics/AgriNav.git
- release repository: https://github.com/SAGARobotics/AgriNav-release.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## polytunnel_navigation_actions

```
* Merge pull request #5 <https://github.com/SAGARobotics/AgriNav/issues/5> from Jailander/master
  Preparing Release
* 0.0.1
* adding changelog
* Merge pull request #4 <https://github.com/SAGARobotics/AgriNav/issues/4> from Jailander/master
  adding nav_msgs as a build dependency
* adding nav_msgs as a build dependency
* Merge pull request #3 <https://github.com/SAGARobotics/AgriNav/issues/3> from Jailander/master
  Moving Polytunnel navigation actions to SAGARobotics Organisation
* Merge branch 'rm_polynav' of ../RASberry
* moving files into the correct directory
* Contributors: Adam Binch, Jaime Pulido Fentanes, jailander
```
