### PR TITLE
depth_sensors: 0.1.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -44,6 +44,19 @@ repositories:
       version: master
     status: developed
   depth_sensors:
+    release:
+      packages:
+      - asus_description
+      - depth_sensors
+      - kinect2_description
+      - kinect_control
+      - kinect_description
+      - senz3d_description
+      - simple_description
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/depth_sensors.git
+      version: 0.1.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `depth_sensors` to `0.1.0-1`:

- upstream repository: https://github.com/LCAS/depth_sensors.git
- release repository: https://github.com/lcas-releases/depth_sensors.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## asus_description

```
* Removed dep from Turtlebot and added meshes here
* Contributors: Riccardo
```

## depth_sensors

- No changes

## kinect2_description

```
* added pi constant
* Contributors: Manuel Fernandez-Carmona
```

## kinect_control

- No changes

## kinect_description

```
* Small fix for xacro
* Contributors: Riccardo
```

## senz3d_description

- No changes

## simple_description

```
* Small fix for xacro
* Contributors: Riccardo
```
