### PR TITLE
image_to_v4l2loopback: 0.1.2-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -161,7 +161,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/image_to_v4l2loopback.git
-      version: 0.1.1-1
+      version: 0.1.2-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `image_to_v4l2loopback` to `0.1.2-1`:

- upstream repository: https://github.com/LCAS/image_to_v4l2loopback.git
- release repository: https://github.com/lcas-releases/image_to_v4l2loopback.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.1.1-1`

## image_to_v4l2loopback

```
* TRAGETS
* Contributors: Marc Hanheide
```
