### PR TITLE
tradr_uol: 1.1.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -735,6 +735,28 @@ repositories:
       version: master
     status: developed
   tradr_uol:
+    release:
+      packages:
+      - exploration_msgs
+      - ms_octomap_mapping
+      - ms_octomap_server
+      - networkanalysis_msgs
+      - nifti_launchers
+      - nifti_robot_description
+      - nifti_robot_driver_msgs
+      - nifti_teleop
+      - patrolling_build_graph_msgs
+      - robot_trajectory_saver_msgs
+      - stamped_msgs
+      - tradr_path_planner
+      - tradr_path_planner_rviz_wp_plugin
+      - tradr_trajectory_control
+      - tradr_trajectory_control_msgs
+      - wireless_network_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/tradr_uol.git
+      version: 1.1.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `tradr_uol` to `1.1.0-1`:

- upstream repository: https://github.com/LCAS/tradr_uol.git
- release repository: https://github.com/lcas-releases/tradr_uol.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## exploration_msgs

- No changes

## ms_octomap_mapping

- No changes

## ms_octomap_server

```
* Move to Melodic [removed ref to vrep simulation]
* Contributors: pulver
```

## networkanalysis_msgs

- No changes

## nifti_launchers

- No changes

## nifti_robot_description

- No changes

## nifti_robot_driver_msgs

- No changes

## nifti_teleop

- No changes

## patrolling_build_graph_msgs

- No changes

## robot_trajectory_saver_msgs

- No changes

## stamped_msgs

- No changes

## tradr_path_planner

- No changes

## tradr_path_planner_rviz_wp_plugin

- No changes

## tradr_trajectory_control

- No changes

## tradr_trajectory_control_msgs

- No changes

## wireless_network_msgs

- No changes
