### PR TITLE
saga_agrinav: 0.0.3-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -367,7 +367,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SAGARobotics/AgriNav-release.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `saga_agrinav` to `0.0.3-1`:

- upstream repository: https://github.com/SAGARobotics/AgriNav.git
- release repository: https://github.com/SAGARobotics/AgriNav-release.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.3`
- previous version for package: `0.0.2-1`

## polytunnel_navigation_actions

```
* Merge pull request #7 <https://github.com/SAGARobotics/AgriNav/issues/7> from Jailander/force_direction
  Adds reconfigurable parameters to force the robot's direction
* Merge pull request #6 <https://github.com/SAGARobotics/AgriNav/issues/6> from Jailander/master
  adding Missing files into the right repo
* Adds reconfigurable parameters to force the robot to go in a specific direction this are to be used with extreme caution
* adding Missing files into the right repo
* Contributors: Jaime Pulido Fentanes, jailander
```
