### PR TITLE
topological_navigation: 1.1.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -725,6 +725,14 @@ repositories:
       version: melodic-devel
     status: developed
   topological_navigation:
+    release:
+      packages:
+      - topological_navigation
+      - topological_utils
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/topological_navigation.git
+      version: 1.1.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `topological_navigation` to `1.1.1-1`:

- upstream repository: https://github.com/LCAS/topological_navigation.git
- release repository: https://github.com/lcas-releases/topological_navigation.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## topological_navigation

```
* Merge pull request #6 <https://github.com/LCAS/topological_navigation/issues/6> from Jailander/master
  Choosing move base action to approach node position following actions…
* Choosing move base action to approach node position following actions order defined in move_base_actions parameter.
  This is very useful to establish priorities across the map
* Merge pull request #5 <https://github.com/LCAS/topological_navigation/issues/5> from adambinch/fix
  Added reconf at edges server as an install target.
* Added reconf at edges server as an install target.
* Merge pull request #2 <https://github.com/LCAS/topological_navigation/issues/2> from Jailander/master
  Importing original version of topological navigation
* Merge branch 'temp_toponav_only' of ../strands_navigation
* moving all files into correct folder
* Contributors: Jaime Pulido Fentanes, Marc Hanheide, adambinch, jailander
```

## topological_utils

```
* Merge pull request #2 <https://github.com/LCAS/topological_navigation/issues/2> from Jailander/master
  Importing original version of topological navigation
* Merge branch 'temp_topoutils_only' of ../strands_navigation
* moving files into the correct folder
* Contributors: Marc Hanheide, jailander
```
