### PR TITLE
topological_navigation: 2.0.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -732,7 +732,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/topological_navigation.git
-      version: 1.1.1-1
+      version: 2.0.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `topological_navigation` to `2.0.0-1`:

- upstream repository: https://github.com/LCAS/topological_navigation.git
- release repository: https://github.com/lcas-releases/topological_navigation.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.1.1-1`

## topological_navigation

- No changes

## topological_utils

- No changes
