### PR TITLE
strands_navigation: 2.0.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -614,11 +614,10 @@ repositories:
       - strands_navigation
       - strands_navigation_msgs
       - topological_logging_manager
-      - topological_rviz_tools
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 1.2.0-1
+      version: 2.0.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `2.0.0-1`:

- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.2.0-1`

## emergency_behaviours

- No changes

## joy_map_saver

- No changes

## monitored_navigation

- No changes

## nav_goals_generator

- No changes

## pose_initialiser

- No changes

## strands_navigation

- No changes

## strands_navigation_msgs

- No changes

## topological_logging_manager

- No changes
