### PR TITLE
strands_navigation: 2.0.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1127,13 +1127,10 @@ repositories:
       - strands_navigation
       - strands_navigation_msgs
       - topological_logging_manager
-      - topological_navigation
-      - topological_rviz_tools
-      - topological_utils
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 1.0.8-1
+      version: 2.0.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `2.0.0-1`:

- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.3`
- previous version for package: `1.0.8-1`

## emergency_behaviours

- No changes

## joy_map_saver

- No changes

## monitored_navigation

- No changes

## nav_goals_generator

- No changes

## pose_initialiser

- No changes

## strands_navigation

- No changes

## strands_navigation_msgs

- No changes

## topological_logging_manager

- No changes
