### PR TITLE
topic_store: 0.0.4-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -732,6 +732,11 @@ repositories:
       version: master
     status: developed
   topic_store:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/topic_store.git
+      version: 0.0.4-1
     source:
       test_commits: true
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_store` to `0.0.4-1`:

- upstream repository: https://github.com/RaymondKirk/topic_store.git
- release repository: https://github.com/lcas-releases/topic_store.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## topic_store

```
* Enable start_database.launch to use system mongo for CI and tests
* Contributors: RaymondKirk
```
