### PR TITLE
saga_agrinav: 0.1.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -380,7 +380,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SAGARobotics/AgriNav-release.git
-      version: 0.0.3-1
+      version: 0.1.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `saga_agrinav` to `0.1.0-1`:

- upstream repository: https://github.com/SAGARobotics/AgriNav.git
- release repository: https://github.com/SAGARobotics/AgriNav-release.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.3-1`

## polytunnel_navigation_actions

```
* Merge pull request #19 <https://github.com/SAGARobotics/AgriNav/issues/19> from Jailander/dyn-error-handling
  Better Dynamic reconfigure error handling
* Better Dynamic reconfigure error handling
* Merge pull request #17 <https://github.com/SAGARobotics/AgriNav/issues/17> from adambinch/install_target
  Added row_detector_vis.py as an install target in cmakelists,
* Added row_detector_vis.py as an install target in cmakelists,
  in order to address https://github.com/LCAS/RASberry/issues/633
* Merge pull request #15 <https://github.com/SAGARobotics/AgriNav/issues/15> from MikHut/set_aborted_cancelled_row_trav
  set action aborted when row traversal cancelled
* set action aborted when row traversal cancelled
* Merge pull request #14 <https://github.com/SAGARobotics/AgriNav/issues/14> from MikHut/increase_row_change_tolerance
  increase row change kp_x and max dist from line
* increase row change kp_x and max dist from line
* Merge pull request #13 <https://github.com/SAGARobotics/AgriNav/issues/13> from adambinch/health_monitoring
  Active: True/False field in row detector health monitor message.
* Merge branch 'master' of https://github.com/SAGARobotics/AgriNav into health_monitoring
* Row detector health monitor topic is published constantly.
  Health monitor msg now has an active: True/False field.
  Removed some redundant code.
* Merge pull request #12 <https://github.com/SAGARobotics/AgriNav/issues/12> from MikHut/pause_if_no_map_tf
  print time without tf
* print time without tf
* Merge pull request #11 <https://github.com/SAGARobotics/AgriNav/issues/11> from adambinch/efficient_pole_filtering
  Row detector wont die if it loses the map to baselink tf transform.
* Row detector wont die if it loses the map to baselink tf transform.
  Rate param set to 10 in common config.
* Merge pull request #10 <https://github.com/SAGARobotics/AgriNav/issues/10> from MikHut/pause_if_no_map_tf
  Pause if no map tf
* Merge branch 'master' of https://github.com/SAGARobotics/AgriNav into pause_if_no_map_tf
* Merge pull request #9 <https://github.com/SAGARobotics/AgriNav/issues/9> from adambinch/efficient_pole_filtering
  Row detector is more efficient.
* stop row traversal if there is no map tf - currently for 1s but reconfiguragle
* Merge pull request #8 <https://github.com/SAGARobotics/AgriNav/issues/8> from MikHut/stop_on_heading_error
  Pause the robot on heading or y error from row
* reduce dev dist y to 0.2
* Base frame retrieved correctly
* Removed redundant code
* Correct geom to calculate max range that filters raw scan data.
* print less row change again
* print less row change
* increase max_dev_dist more
* increase max_dev_dist
* set active false
* minor change
* Adjusted rate in configs
* update
* tidying prints
* increase y dev pause error to 0.25 from 0.18
* adjustments
* fix
* Pole filtering should be more efficient.
  Rather than checking a detected pole's position against *all* the pole positions recorded in the map,
  the detected pole's position is compared against map-recorded pole positions located in a moving circular window,
  whose centre point corresponds to the map to baselink tf transform.
  The radius of this circle is set to 2 X the max radius specified in the ellipse config.
  Needs to be tested for CPU load.
* cancel on max dist instead of pause - note, not dev dist y or angle (which pause) just overall from line to cancel action and start toponav again
* write message when line deivation is okay
* add paused to health message so we can be notified vie sentor/slack of robot pausing
* remove unncessary lines from row change
* pause robot during row traversal if large ang or y errors from row
* Contributors: Adam Binch, Jaime Pulido Fentanes, Michael Hutchinson, MikHut, adambinch, jailander
```
