### PR TITLE
uol_cmp9767m: 0.6.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -827,6 +827,14 @@ repositories:
       version: indigo-devel
     status: maintained
   uol_cmp9767m:
+    release:
+      packages:
+      - uol_cmp9767m_base
+      - uol_cmp9767m_tutorial
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/CMP9767M.git
+      version: 0.6.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `uol_cmp9767m` to `0.6.0-1`:

- upstream repository: https://github.com/LCAS/CMP9767M.git
- release repository: https://github.com/lcas-releases/CMP9767M.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`

## uol_cmp9767m_base

```
* Merge pull request #55 <https://github.com/LCAS/CMP9767M/issues/55> from LCAS/melodic-devel
  Melodic devel
* thorvald tf_prefix must have a / at tail end (#51 <https://github.com/LCAS/CMP9767M/issues/51>)
  * thorvald tf_prefix must have a / at tail end
  * gazebo model hook fix
  * re-enabling kinect2
* Merge branch 'master' into melodic-devel
* fix gazebo model path hook (#54 <https://github.com/LCAS/CMP9767M/issues/54>)
  minor fix to GAZEBO_MODEL_PATH env hook.
* New world and materials to simulate non-uniform rows. Usage: roslaunch uol_cmp9767m_base thorvald-sim.launch world_name:=`rospack find uol_cmp9767m_base`/worlds/cmp9767m_paper_4.world (#49 <https://github.com/LCAS/CMP9767M/issues/49>)
* Merge pull request #48 <https://github.com/LCAS/CMP9767M/issues/48> from LCAS/paper_sim
  Additional worlds for running evaluations for the paper.
* Additional worlds for running evaluations for the paper. thorvald-sim.launch accepts now world_name as a parameter. Example usage: roslaunch uol_cmp9767m_base thorvald-sim.launch world_name:=`rospack find uol_cmp9767m_base`/worlds/cmp9767m_paper_1.world
* Merge branch 'master' into melodic-devel
* shifted position (#47 <https://github.com/LCAS/CMP9767M/issues/47>)
* disable actor collisions
* removed kinect2 dep for now
* fixed meshes for melodic
* fixed for melodic
* Contributors: Gautham P Das, Grzegorz Cielniak, Marc Hanheide, gcielniak
```

## uol_cmp9767m_tutorial

```
* Merge pull request #55 <https://github.com/LCAS/CMP9767M/issues/55> from LCAS/melodic-devel
  Melodic devel
* thorvald tf_prefix must have a / at tail end (#51 <https://github.com/LCAS/CMP9767M/issues/51>)
  * thorvald tf_prefix must have a / at tail end
  * gazebo model hook fix
  * re-enabling kinect2
* Merge branch 'master' into melodic-devel
* Contributors: Gautham P Das, Marc Hanheide
```
