### PR TITLE
saga_agrinav: 0.1.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -380,7 +380,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SAGARobotics/AgriNav-release.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `saga_agrinav` to `0.1.1-1`:

- upstream repository: https://github.com/SAGARobotics/AgriNav.git
- release repository: https://github.com/SAGARobotics/AgriNav-release.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.1.0-1`

## polytunnel_navigation_actions

```
* Merge pull request #22 <https://github.com/SAGARobotics/AgriNav/issues/22> from MikHut/gauthams_patch
  gauthams wheel frame id patch for multi sim LCAS/RASberry#634 <https://github.com/LCAS/RASberry/issues/634>
* added base frame param to row change
* wheel alignment frame id patch applied to row change
* gauthams wheel frame id patch for multi sim LCAS/RASberry#634 <https://github.com/LCAS/RASberry/issues/634>
* Merge pull request #21 <https://github.com/SAGARobotics/AgriNav/issues/21> from MikHut/row_trav_update
  tidy error prints from row trav and row change, also abort row change…
* tidy error prints from row trav and row change, also abort row change if cancelled so toponav replans
* Merge pull request #20 <https://github.com/SAGARobotics/AgriNav/issues/20> from MikHut/row_trav_update
  check whether we are using row detector even if continuing row trav
* check whether we are using row detector even if continuing row trav
* Contributors: Michael Hutchinson, MikHut
```
