### PR TITLE
librealsense2_framos: 2.29.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -198,6 +198,11 @@ repositories:
       version: master
     status: maintained
   librealsense2_framos:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/librealsense_framos.git
+      version: 2.29.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2_framos` to `2.29.1-1`:

- upstream repository: https://github.com/LCAS/librealsense.git
- release repository: https://github.com/lcas-releases/librealsense_framos.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.3`
- previous version for package: `null`
