### PR TITLE
realsense_framos_ros: 3.0.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -318,6 +318,14 @@ repositories:
       version: master
     status: developed
   realsense_framos_ros:
+    release:
+      packages:
+      - realsense2_framos_camera
+      - realsense2_framos_description
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/realsense_framos_ros.git
+      version: 3.0.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_framos_ros` to `3.0.0-1`:

- upstream repository: https://github.com/LCAS/realsense.git
- release repository: https://github.com/lcas-releases/realsense_framos_ros.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## realsense2_framos_camera

```
* added dependency and maintainer
* changed to correct libs
* renaming complete, compiles
* renamed dirs
* Contributors: Marc Hanheide
* Add eigen dependency - missing for Melodic. Contributors: Antoine Hoarau
```

## realsense2_framos_description

```
* renaming complete, compiles
* renamed dirs
* Contributors: Marc Hanheide
```
