### PR TITLE
realsense_framos_ros: 3.0.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -325,7 +325,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/realsense_framos_ros.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_framos_ros` to `3.0.1-1`:

- upstream repository: https://github.com/LCAS/realsense.git
- release repository: https://github.com/lcas-releases/realsense_framos_ros.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.0.0-1`

## realsense2_framos_camera

```
* handle config file correctly
* Contributors: Marc Hanheide
```

## realsense2_framos_description

```
* changed maintainer
* Contributors: Marc Hanheide
```
