### PR TITLE
velodyne_oru: 1.5.6-2 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -1451,7 +1451,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/velodyne-release.git
-      version: 1.5.5-1
+      version: 1.5.6-2
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_oru` to `1.5.6-2`:

- upstream repository: https://github.com/dan11003/velodyne_pointcloud_oru
- release repository: https://github.com/LCAS/velodyne-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.5.5-1`

## velodyne_pointcloud_oru

```
* added functionallity to unpack pointcloud without filtering non-returns
* Contributors: mailto:dla.adolfsson@gmail.com
```
