### PR TITLE
ndt_core: 2.3.1-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -465,7 +465,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/ndt_core-release.git
-      version: 2.3.0-1
+      version: 2.3.1-1
     source:
       test_commits: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ndt_core` to `2.3.1-1`:

- upstream repository: https://gitsvn-nt.oru.se/software/ndt_core.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/ndt_core-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.3.0-1`

## ndt_core

- No changes

## ndt_generic

```
* added vector to file output
* added newline
* added function to save vector of poses to text file
* Merge branch 'master' of https://gitsvn-nt.oru.se/software/ndt_core
* added serialization for quaterniond
* updated point coud conversion
* Merge branch 'master' of https://gitsvn-nt.oru.se/software/ndt_core
* added endl to eval strings output
* malcolm: added missing pcl dependencies
  I added the missing PCL conversion and ros dependencies
* Contributors: Malcolm Mielle, daniel, daniel adolfsson, mailto:dla.adolfsson@gmail.com
```

## ndt_map

- No changes

## ndt_registration

```
* Merge branch 'master' of https://gitsvn-nt.oru.se/software/ndt_core
* Merge branch 'master' of https://gitsvn-nt.oru.se/software/ndt_core
* added endl to eval strings output
* updated registration covariance
* Contributors: daniel, mailto:dla.adolfsson@gmail.com
```

## ndt_rviz

- No changes

## ndt_visualisation

- No changes
