### PR TITLE
velodyne_oru: 1.5.6-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -870,7 +870,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/LCAS/velodyne-release.git
-      version: 1.5.5-1
+      version: 1.5.6-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `velodyne_oru` to `1.5.6-1`:

- upstream repository: https://github.com/dan11003/velodyne_pointcloud_oru
- release repository: https://github.com/LCAS/velodyne-release.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.7`
- previous version for package: `1.5.5-1`

## velodyne_pointcloud_oru

```
* added functionallity to unpack pointcloud without filtering non-returns
* Contributors: mailto:dla.adolfsson@gmail.com
```
