### PR TITLE
ndt_tools: 2.0.3-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -483,7 +483,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/ndt_tools-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       test_commits: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ndt_tools` to `2.0.3-1`:

- upstream repository: https://gitsvn-nt.oru.se/software/ndt_tools.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/ndt_tools-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.0.2-1`

## ndt_feature_finder

```
* malcolm: missing dependencies+corrected string
  I've added missing dependencies in ndt_feature_finder and ndt_offline
  Furthermore, I've corrected on string_cxx11 by changing it to std.string
* Contributors: Malcolm Mielle
```

## ndt_fuser

```
* malcolm: missing dependencies+corrected string
  I've added missing dependencies in ndt_feature_finder and ndt_offline
  Furthermore, I've corrected on string_cxx11 by changing it to std.string
* Contributors: Malcolm Mielle
```

## ndt_localization

```
* updated tf_writer
* Contributors: mailto:dla.adolfsson@gmail.com
```

## ndt_offline

```
* Added functionallity to read full pointcloud withit filtering
* updated point cloud reader
* updated tf_writer
* malcolm: missing dependencies+corrected string
  I've added missing dependencies in ndt_feature_finder and ndt_offline
  Furthermore, I've corrected on string_cxx11 by changing it to std.string
* Contributors: Malcolm Mielle, daniel adolfsson, mailto:dla.adolfsson@gmail.com
```

## ndt_tools

- No changes
