### PR TITLE
realsense_gazebo_plugin: 0.1.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -338,7 +338,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/realsense_gazebo_plugin.git
-      version: 0.0.1-1
+      version: 0.1.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_gazebo_plugin` to `0.1.0-1`:

- upstream repository: https://github.com/LCAS/realsense_gazebo_plugin.git
- release repository: https://github.com/lcas-releases/realsense_gazebo_plugin.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.1-1`

## realsense_gazebo_plugin

```
* Merge pull request #1 <https://github.com/LCAS/realsense_gazebo_plugin/issues/1> from Melanoneiro/master
  Add Registered Depth Stream
* fix: Remove necessity of having registered depth cam enabling backwards compatibiliy
* feat: Add registered depth stream
* Contributors: Marc Hanheide, Nikolaus Wagner
```
