### PR TITLE
bacchus_lcas: 0.0.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -18,6 +18,13 @@ repositories:
       version: stable
     status: maintained
   bacchus_lcas:
+    release:
+      packages:
+      - bacchus_gazebo
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/bacchus_lcas.git
+      version: 0.0.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `bacchus_lcas` to `0.0.1-1`:

- upstream repository: https://github.com/LCAS/bacchus_lcas.git
- release repository: https://github.com/lcas-releases/bacchus_lcas.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.7`
- previous version for package: `null`

## bacchus_gazebo

```
* renamed file
* changed to cmp9767m base
* removed outdated deps
* removed outdated deps
* version
* initial commit
* Contributors: Marc Hanheide
```
