### PR TITLE
topic_store: 0.0.7-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -785,7 +785,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/topic_store.git
-      version: 0.0.6-1
+      version: 0.0.7-1
     source:
       test_commits: true
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_store` to `0.0.7-1`:

- upstream repository: https://github.com/RaymondKirk/topic_store.git
- release repository: https://github.com/lcas-releases/topic_store.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.6-1`

## topic_store

```
* Added verbose print to TopicStore objects (ROSType and Document Size)
* Force subscriber when data storage key starts with '/'
  Otherwise if topics don't exist when data collection starts then the topics will never be subscribed to
* Contributors: RaymondKirk
```
