### PR TITLE
topic_store: 0.1.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -785,7 +785,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/topic_store.git
-      version: 0.0.9-1
+      version: 0.1.0-1
     source:
       test_commits: true
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_store` to `0.1.0-1`:

- upstream repository: https://github.com/RaymondKirk/topic_store.git
- release repository: https://github.com/lcas-releases/topic_store.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.7`
- previous version for package: `0.0.9-1`

## topic_store

```
* Merge pull request #6 <https://github.com/RaymondKirk/topic_store/issues/6> from RaymondKirk/fix_for_msg_depth_bug
  GridFS improvements and fix for nested permutations of (dict -> list -> object) such as TF messages
* Updated README to reflect recent changes
* Store original document and session ID in file meta of GridFS documents (for cleanup)
* Fix for incompatible parsing of a dict -> list -> dict -> etc type nests
  Search depth first (takes much longer though) but TF and other messages now supported
* Fixes to conversion script (to rosbag from mongo/topic storage)
* Attempt to fix nested dict recursion to fix ROS messages
  Still having issues with TF messages but most others work. Problem is nested dicts of lists of dicts aren't parsed correctly with the _ros_meta field.
* Contributors: Raymond Tunstill (Kirk), RaymondKirk
```
