### PR TITLE
librealsense2_framos: 2.33.2-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -217,7 +217,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/librealsense_framos.git
-      version: 2.29.2-1
+      version: 2.33.2-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `librealsense2_framos` to `2.33.2-1`:

- upstream repository: https://github.com/LCAS/librealsense.git
- release repository: https://github.com/lcas-releases/librealsense_framos.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.7`
- previous version for package: `2.29.2-1`

## librealsense2_framos

```
* Corrected URL
* Removed external maintainer
* Merge pull request #3 <https://github.com/LCAS/librealsense/issues/3> from nikostsagk/2.33-WIP
  More renaming.
* More renaming.
* Add -framos suffix to binaries
* I don't know why I commented this
* add deps
* set hard paths
* added default path
* install udev in release mode
* changed name and added framos dependencies
* Copied over from FRAMOS deb package
* Contributors: Marc Hanheide, nikostsagk
```
