### PR TITLE
realsense_framos_ros: 3.2.14-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -340,7 +340,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/realsense_framos_ros.git
-      version: 3.0.2-2
+      version: 3.2.14-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `realsense_framos_ros` to `3.2.14-1`:

- upstream repository: https://github.com/LCAS/realsense.git
- release repository: https://github.com/lcas-releases/realsense_framos_ros.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.7`
- previous version for package: `3.0.2-2`

## realsense2_framos_camera

```
* Merge pull request #5 <https://github.com/LCAS/realsense/issues/5> from LCAS/for_v2.33
  imported from FRAMOS packages
* imported from FRAMOS packages
* added logging to show it's FRAMOS
* Contributors: Marc Hanheide
```

## realsense2_framos_description

```
* Merge pull request #5 <https://github.com/LCAS/realsense/issues/5> from LCAS/for_v2.33
  imported from FRAMOS packages
* imported from FRAMOS packages
* Contributors: Marc Hanheide
```
