### PR TITLE
spencer_people_tracking: 1.0.11-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -966,7 +966,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lcas-releases/spencer_people_tracking.git
-      version: 1.0.10-0
+      version: 1.0.11-1
     source:
       type: git
       url: https://github.com/spencer-project/spencer_people_tracking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `spencer_people_tracking` to `1.0.11-1`:

- upstream repository: https://github.com/spencer-project/spencer_people_tracking.git
- release repository: https://github.com/lcas-releases/spencer_people_tracking.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.0.10-0`

## pcl_people_detector

```
* Use find_package(Eigen3) instead of find_package(Eigen)
* Contributors: Timm Linder
```

## rwth_ground_hog

```
* Merge pull request #81 <https://github.com/spencer-project/spencer_people_tracking/issues/81> from LCAS/master
  Changelog updates from LCAS buildfarm
* Contributors: Timm Linder
```

## rwth_ground_plane

```
* Various smaller fixes for ROS Kinetic
  - Fix build warnings in laser_features and rwth_ground_plane
  - Configurable odom and base footprint frame IDs (fixes #53 <https://github.com/spencer-project/spencer_people_tracking/issues/53>)
* Contributors: Timm Linder
```

## rwth_perception_people_msgs

```
* Merge pull request #81 <https://github.com/spencer-project/spencer_people_tracking/issues/81> from LCAS/master
  Changelog updates from LCAS buildfarm
* Contributors: Timm Linder
```

## rwth_upper_body_detector

```
* Adapt stability fixes to upper-body detector + config changes from LCAS (provided by Manuel in pull request #59 <https://github.com/spencer-project/spencer_people_tracking/issues/59>, commit e5ca86b28c99) to the SPENCER version.
* Merge branch 'master' of https://github.com/MFernandezCarmona/spencer_people_tracking into master
* Merge pull request #52 <https://github.com/spencer-project/spencer_people_tracking/issues/52> from Sangheli/patch-1
  In upper-body detector, use correct dimensions of depth image (important when not using VGA resolution; otherwise part of image might not be used for detection)
* Fixed depth image converting to matrix when resolution!=640x480
* Contributors: Manuel Fernandez-Carmona, Timm Linder, Андрей Савельев
```

## spencer_bagfile_tools

```
* Contributors: Timm Linder
```

## spencer_control_msgs

```
* Merge pull request #81 <https://github.com/spencer-project/spencer_people_tracking/issues/81> from LCAS/master
  Changelog updates from LCAS buildfarm
* Contributors: Timm Linder
```

## spencer_detected_person_association

```
* Various smaller fixes for ROS Kinetic
  - Reduce logging level at nodelet startup to remove logging clutter
  - Bugfix for #78 <https://github.com/spencer-project/spencer_people_tracking/issues/78>, blocked aggregator nodelets due to detector stall. Fix by monitoring if any message are actually received on detections topic, before advertising publisher.
  - Configurable odom and base footprint frame IDs (fixes #53 <https://github.com/spencer-project/spencer_people_tracking/issues/53>)
* Contributors: Timm Linder
```

## spencer_detected_person_conversion

```
* Merge pull request #81 <https://github.com/spencer-project/spencer_people_tracking/issues/81> from LCAS/master
  Changelog updates from LCAS buildfarm
* Contributors: Timm Linder
```

## spencer_diagnostics

```
* Merge pull request #81 <https://github.com/spencer-project/spencer_people_tracking/issues/81> from LCAS/master
  Changelog updates from LCAS buildfarm
* Contributors: Timm Linder
```

## spencer_group_tracking

```
* Merge pull request #81 <https://github.com/spencer-project/spencer_people_tracking/issues/81> from LCAS/master
  Changelog updates from LCAS buildfarm
* Contributors: Timm Linder
```

## spencer_human_attribute_msgs

```
* Merge pull request #81 <https://github.com/spencer-project/spencer_people_tracking/issues/81> from LCAS/master
  Changelog updates from LCAS buildfarm
* Contributors: Timm Linder
```

## spencer_leg_detector_wrapper

```
* Add missing install targets for spencer_leg_detector_wrapper (fix for #64 <https://github.com/spencer-project/spencer_people_tracking/issues/64>)
* Contributors: Timm Linder
```

## spencer_people_tracking_full

```
* Contributors: Timm Linder
```

## spencer_people_tracking_launch

```
* Various smaller fixes for ROS Kinetic
  - Configurable odom and base footprint frame IDs (fixes #53 <https://github.com/spencer-project/spencer_people_tracking/issues/53>)
* Restore functionality of srl_laser_detectors by replacing old trained models (broken due to changes in Eigen and OpenCV) with new ones.
* Merge pull request #54 <https://github.com/spencer-project/spencer_people_tracking/issues/54> from rpg711/fix_openni1
  Fixing detection remapping so detections are actually published to rviz for openni 1
* Fixing detection remapping so detections are actually published to rviz correctly
* Contributors: Timm Linder, rpg711
```

## spencer_perception_mocks

```
* Merge pull request #81 <https://github.com/spencer-project/spencer_people_tracking/issues/81> from LCAS/master
  Changelog updates from LCAS buildfarm
* Contributors: Timm Linder
```

## spencer_social_relation_msgs

```
* Merge pull request #81 <https://github.com/spencer-project/spencer_people_tracking/issues/81> from LCAS/master
  Changelog updates from LCAS buildfarm
* Contributors: Timm Linder
```

## spencer_social_relations

```
* Various smaller fixes for ROS Kinetic
  - Use find_package(Eigen3) instead of find_package(Eigen)
  - Configurable odom and base footprint frame IDs (fixes #53 <https://github.com/spencer-project/spencer_people_tracking/issues/53>)
* Contributors: Timm Linder
```

## spencer_tracking_metrics

```
* Merge pull request #81 <https://github.com/spencer-project/spencer_people_tracking/issues/81> from LCAS/master
  Changelog updates from LCAS buildfarm
* Contributors: Timm Linder
```

## spencer_tracking_msgs

```
* Merge pull request #81 <https://github.com/spencer-project/spencer_people_tracking/issues/81> from LCAS/master
  Changelog updates from LCAS buildfarm
* Contributors: Timm Linder
```

## spencer_tracking_rviz_plugin

```
* Various smaller fixes for ROS Kinetic
  - Use find_package(Eigen3) instead of find_package(Eigen)
  - Configurable odom and base footprint frame IDs (fixes #53 <https://github.com/spencer-project/spencer_people_tracking/issues/53>)
* Contributors: Timm Linder
```

## spencer_tracking_utils

```
* Various smaller fixes for ROS Kinetic
  - Use find_package(Eigen3) instead of find_package(Eigen)
  - Configurable odom and base footprint frame IDs (fixes #53 <https://github.com/spencer-project/spencer_people_tracking/issues/53>)
  - Updated README
* Contributors: Timm Linder
```

## spencer_vision_msgs

```
* Merge pull request #1 <https://github.com/spencer-project/spencer_people_tracking/issues/1> from spencer-project/master
  Adding confidence field to PersonROI message
* Contributors: Manuel Fernandez-Carmona, Timm Linder
```

## srl_laser_detectors

```
* Restore functionality of srl_laser_detectors by replacing old trained models (broken due to changes in Eigen and OpenCV) with new ones.
  Training functionality restored by slight revision of training ROS node according to new protocol.
  Improved error handling in laser detectors.
  Include boundary dist feature to ensure compatibility of trained models.
  Fix compiler warnings in getDescription() method of laser features.
* Contributors: Timm Linder
```

## srl_laser_features

```
* Restore functionality of srl_laser_detectors by replacing old trained models (broken due to changes in Eigen and OpenCV) with new ones.
  Training functionality restored by slight revision of training ROS node according to new protocol.
  Improved error handling in laser detectors.
  Include boundary dist feature to ensure compatibility of trained models.
  Fix compiler warnings in getDescription() method of laser features.
* Contributors: Timm Linder
```

## srl_laser_segmentation

```
* Restore functionality of srl_laser_detectors by replacing old trained models (broken due to changes in Eigen and OpenCV) with new ones.
  Training functionality restored by slight revision of training ROS node according to new protocol.
  Improved error handling in laser detectors.
  Include boundary dist feature to ensure compatibility of trained models.
  Fix compiler warnings in getDescription() method of laser features.
* Contributors: Timm Linder
```

## srl_nearest_neighbor_tracker

```
* Various smaller fixes for ROS Kinetic
  - Use find_package(Eigen3) instead of find_package(Eigen)
  - Configurable odom and base footprint frame IDs (fixes #53 <https://github.com/spencer-project/spencer_people_tracking/issues/53>)
* Revert added params for topic remapping introduced in pull request #59 <https://github.com/spencer-project/spencer_people_tracking/issues/59> (commits e5ca86b28c and 6255cfe76).
  The naming of these parameters is a bit inconsistent and support was added to only few selected ROS nodes. Therefore, it is better to rely on traditional topic remappings for now.
* Contributors: Timm Linder
```

## srl_tracking_exporter

```
* Merge pull request #65 <https://github.com/spencer-project/spencer_people_tracking/issues/65> from dandedrick/fix-logerror
  job_monitor: replace logerror with logerr
* job_monitor: replace logerror with logerr
  rospy doesn't export a logerror symbol only logerr. If this was ever hit it
  would have caused an exception instead of logging.
* Contributors: Dan Dedrick, Timm Linder
```

## srl_tracking_logfile_import

```
* Restore functionality of srl_laser_detectors by replacing old trained models (broken due to changes in Eigen and OpenCV) with new ones.
  Training functionality restored by slight revision of training ROS node according to new protocol.
* Contributors: Timm Linder
```

## track_annotation_tool

```
* Merge pull request #81 <https://github.com/spencer-project/spencer_people_tracking/issues/81> from LCAS/master
  Changelog updates from LCAS buildfarm
* Contributors: Timm Linder
```

## video_to_bagfile

```
* Merge pull request #81 <https://github.com/spencer-project/spencer_people_tracking/issues/81> from LCAS/master
  Changelog updates from LCAS buildfarm
* Contributors: Timm Linder
```
