### PR TITLE
topic_store: 0.1.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -822,7 +822,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/topic_store.git
-      version: 0.1.0-1
+      version: 0.1.1-1
     source:
       test_commits: true
       test_pull_requests: false


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_store` to `0.1.1-1`:

- upstream repository: https://github.com/RaymondKirk/topic_store.git
- release repository: https://github.com/lcas-releases/topic_store.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.8`
- previous version for package: `0.1.0-1`

## topic_store

```
* Merge pull request #7 <https://github.com/RaymondKirk/topic_store/issues/7> from RaymondKirk/add_action_server_video
  Added ability to collect sequences with the action server
* Added ability to collect sequences with the action server
* Contributors: Raymond Tunstill (Kirk), RaymondKirk
```
