### PR TITLE
spencer_people_tracking: 1.2.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -590,7 +590,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/spencer_people_tracking.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       test_commits: false
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `spencer_people_tracking` to `1.2.1-1`:

- upstream repository: https://github.com/spencer-project/spencer_people_tracking.git
- release repository: https://github.com/lcas-releases/spencer_people_tracking.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.9.8`
- previous version for package: `1.2.0-1`

## pcl_people_detector

- No changes

## rwth_ground_hog

- No changes

## rwth_ground_plane

- No changes

## rwth_perception_people_msgs

- No changes

## rwth_upper_body_detector

- No changes

## spencer_bagfile_tools

- No changes

## spencer_control_msgs

- No changes

## spencer_detected_person_association

- No changes

## spencer_detected_person_conversion

- No changes

## spencer_diagnostics

- No changes

## spencer_group_tracking

- No changes

## spencer_human_attribute_msgs

- No changes

## spencer_leg_detector_wrapper

- No changes

## spencer_people_tracking_full

- No changes

## spencer_people_tracking_launch

- No changes

## spencer_perception_mocks

- No changes

## spencer_social_relation_msgs

- No changes

## spencer_social_relations

- No changes

## spencer_tracking_metrics

- No changes

## spencer_tracking_msgs

- No changes

## spencer_tracking_rviz_plugin

```
* Fix Qt5 cmake module not being found
* Contributors: Timm Linder
```

## spencer_tracking_utils

- No changes

## spencer_vision_msgs

- No changes

## srl_laser_detectors

- No changes

## srl_laser_features

- No changes

## srl_laser_segmentation

- No changes

## srl_nearest_neighbor_tracker

- No changes

## srl_tracking_exporter

- No changes

## srl_tracking_logfile_import

- No changes

## track_annotation_tool

```
* Fix Qt5 cmake module not being found
* Contributors: Timm Linder
```

## video_to_bagfile

- No changes
