### PR TITLE
bacchus_lcas: 0.2.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -21,10 +21,11 @@ repositories:
     release:
       packages:
       - bacchus_gazebo
+      - bacchus_move_base
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/bacchus_lcas.git
-      version: 0.0.1-1
+      version: 0.2.0-1
     source:
       test_commits: true
       test_pull_requests: true
@@ -424,6 +425,14 @@ repositories:
       url: https://github.com/SAGARobotics/AgriNav.git
       version: master
     status: developed
+  saga_apps:
+    source:
+      test_commits: true
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SAGARobotics/SagaApps.git
+      version: master
+    status: developed
   sandbox:
     release:
       packages:
@@ -808,14 +817,6 @@ repositories:
       type: git
       url: https://github.com/SAGARobotics/Thorvald.git
       version: melodic-devel
-    status: developed
-  saga_apps:
-    source:
-      test_commits: true
-      test_pull_requests: true
-      type: git
-      url: https://github.com/SAGARobotics/SagaApps.git
-      version: master
     status: developed
   topic_store:
     release:


### PR DESCRIPTION
Increasing version of package(s) in repository `bacchus_lcas` to `0.2.0-1`:

- upstream repository: https://github.com/LCAS/bacchus_lcas.git
- release repository: https://github.com/lcas-releases/bacchus_lcas.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.0.1-1`

## bacchus_gazebo

```
* Merge pull request #6 <https://github.com/LCAS/bacchus_lcas/issues/6> from LCAS/better_download_models
  Better build and demo
* improved the download build and also allow rviz navigation
* Contributors: Marc Hanheide
```

## bacchus_move_base

```
* Merge pull request #6 <https://github.com/LCAS/bacchus_lcas/issues/6> from LCAS/better_download_models
  Better build and demo
* improved the download build and also allow rviz navigation
* Contributors: Marc Hanheide
* Merge branch 'master' into vine_stages
* Update costmap_common_params.yaml
* Update move_base_dwa_multisim.launch
* Update vineyard_demo_goals.txt
* Merge pull request #3 <https://github.com/LCAS/bacchus_lcas/issues/3> from LCAS/new_sim_sergi
  adding move base and main launch file
* adding move base and main launch file
* Contributors: Ibrahim Hroob, Sergi Molina, sergimolina
```
