### PR TITLE
bacchus_lcas: 0.2.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -25,7 +25,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/bacchus_lcas.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `bacchus_lcas` to `0.2.1-1`:

- upstream repository: https://github.com/LCAS/bacchus_lcas.git
- release repository: https://github.com/lcas-releases/bacchus_lcas.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.2.0-1`

## bacchus_gazebo

```
* fix deps
* Contributors: Marc Hanheide
```

## bacchus_move_base

```
* fix deps
* Contributors: Marc Hanheide
```
