### PR TITLE
topological_navigation: 2.2.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -834,13 +834,14 @@ repositories:
   topological_navigation:
     release:
       packages:
+      - bayesian_topological_localisation
       - topological_navigation
       - topological_rviz_tools
       - topological_utils
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/topological_navigation.git
-      version: 2.1.0-1
+      version: 2.2.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `topological_navigation` to `2.2.0-1`:

- upstream repository: https://github.com/LCAS/topological_navigation.git
- release repository: https://github.com/lcas-releases/topological_navigation.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.0`
- previous version for package: `2.1.0-1`

## bayesian_topological_localisation

```
* Merge pull request #48 <https://github.com/LCAS/topological_navigation/issues/48> from Jailander/new-pkg-version
  Making package version number compatible with other packages for release
* Making package version number compatible with other packages for release
* Merge pull request #43 <https://github.com/LCAS/topological_navigation/issues/43> from francescodelduchetto/master
  Topological localization package
* Update README.md
* Re-initialize particles when the weighting from pose is too little wrt particles; allow small chance of jumping to unconnected nodes
* get current time when receiving message instead of message time to avoid problems when time received is not accurate enough
* current_node is now estimated_node, because it's more clear wrt what it contains
* implemented services for sending observations and getting localisation result back
* handle with warning when observation is completely disjoint from prediction
* renaming to bayesian_topological_localisation
* Contributors: Jaime Pulido Fentanes, francescodelduchetto, jailander
```
