### PR TITLE
iliad_smp: 0.3.3-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -263,7 +263,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/restricted-releases.git
-      version: 0.3.2-1
+      version: 0.3.3-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_smp` to `0.3.3-1`:

- upstream repository: https://gitsvn-nt.oru.se/palmieri/iliad_smp.git
- release repository: https://github.com/LCAS/restricted-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.10.0`
- previous version for package: `0.3.2-1`

## iliad_smp_global_planner

```
* CLiFF with PRM*
* Contributors: Luigi Palmieri (Robert Bosch GmbH, CR/AAS3)
```
