### PR TITLE
mqtt_bridge_lcas: 1.0.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -284,6 +284,13 @@ repositories:
       version: master
     status: maintained
   mqtt_bridge_lcas:
+    release:
+      packages:
+      - mqtt_bridge
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/mqtt_bridge.git
+      version: 1.0.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_bridge_lcas` to `1.0.0-1`:

- upstream repository: https://github.com/LCAS/mqtt_bridge.git
- release repository: https://github.com/lcas-releases/mqtt_bridge.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## mqtt_bridge

```
* 0.2.1
* changelog
* changed version number
* example now also has DynamicServer example
  and further examples of qos and latch
* action server launch file is working
  with prefix and dynamic server
* DynamicServer implementation working
* added launching own MQTT server
* removed
* intial actionlib mqtt setup
* support for latched (retained) topics and QoS
* ignore vscode
* changed maintainer
* fix install target for directories
* Contributors: Marc Hanheide
```
