### PR TITLE
mqtt_bridge_lcas: 1.0.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -290,7 +290,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/mqtt_bridge.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_bridge_lcas` to `1.0.1-1`:

- upstream repository: https://github.com/LCAS/mqtt_bridge.git
- release repository: https://github.com/lcas-releases/mqtt_bridge.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.0.0-1`

## mqtt_bridge

```
* missing install target
* Merge branch 'pr_upstream' into melodic-devel
* example now also has DynamicServer example
  and further examples of qos and latch
* action server launch file is working
  with prefix and dynamic server
* DynamicServer implementation working
* added launching own MQTT server
* removed
* intial actionlib mqtt setup
* support for latched (retained) topics and QoS
* Contributors: Marc Hanheide
```
