### PR TITLE
mqtt_bridge_lcas: 1.2.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -290,7 +290,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/mqtt_bridge.git
-      version: 1.1.0-1
+      version: 1.2.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_bridge_lcas` to `1.2.0-1`:

- upstream repository: https://github.com/LCAS/mqtt_bridge.git
- release repository: https://github.com/lcas-releases/mqtt_bridge.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.0`
- previous version for package: `1.1.0-1`

## mqtt_bridge

```
* added LocalServiceProxy
* renamed to RemoteService
* Contributors: Marc Hanheide
```
