### PR TITLE
mqtt_bridge_lcas: 1.2.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -445,6 +445,15 @@ repositories:
       url: https://github.com/strands-project/mongodb_store.git
       version: kinetic-devel
     status: developed
+  mqtt_bridge_lcas:
+    release:
+      packages:
+      - mqtt_bridge
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/lcas-releases/mqtt_bridge.git
+      version: 1.2.0-1
+    status: developed
   ncnr_uol:
     source:
       test_commits: true


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_bridge_lcas` to `1.2.0-1`:

- upstream repository: https://github.com/LCAS/mqtt_bridge.git
- release repository: https://github.com/lcas-releases/mqtt_bridge.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.10.0`
- previous version for package: `null`

## mqtt_bridge

```
* added LocalServiceProxy
* renamed to RemoteService
* Contributors: Marc Hanheide
```
