### PR TITLE
uol_cmp9767m: 0.6.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -966,7 +966,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/CMP9767M.git
-      version: 0.6.0-1
+      version: 0.6.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `uol_cmp9767m` to `0.6.1-1`:

- upstream repository: https://github.com/LCAS/CMP9767M.git
- release repository: https://github.com/lcas-releases/CMP9767M.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.1`
- previous version for package: `0.6.0-1`

## uol_cmp9767m_base

- No changes

## uol_cmp9767m_tutorial

```
* Merge pull request #60 <https://github.com/LCAS/CMP9767M/issues/60> from gcielniak/master
  Corrected cmake file configuration for its use with actionlib
* Merge pull request #3 <https://github.com/LCAS/CMP9767M/issues/3> from gcielniak/work9_actions
  missing actionlib_msgs in CMakeLists.txt
* missing actionlib_msgs in CMakeLists.txt
* Merge pull request #59 <https://github.com/LCAS/CMP9767M/issues/59> from gcielniak/master
  additional rviz config files
* Merge pull request #1 <https://github.com/LCAS/CMP9767M/issues/1> from gcielniak/work6_ekf_rviz
  Work6 ekf rviz
* acml rviz config file
* Merge pull request #57 <https://github.com/LCAS/CMP9767M/issues/57> from gcielniak/work6_ekf_rviz
  tutorial 6: rviz config for ekf
* tutorial 6: rviz config for ekf
* added simple opencv code
* more documentation
* added the publishing of a PoseStamped
* made it OOP and added documentation
* some adjustments to the tf listener
* added documentation
* changed forward speed to 2.0
* added two OOP examples
* Create freemem.sh
* Create freemem.py
* minor fixes for frame namespacing (#56 <https://github.com/LCAS/CMP9767M/issues/56>)
* Contributors: Gautham P Das, Marc Hanheide, gcielniak
```
