### PR TITLE
mqtt_bridge_lcas: 1.2.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -291,7 +291,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/mqtt_bridge.git
-      version: 1.2.0-1
+      version: 1.2.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_bridge_lcas` to `1.2.1-1`:

- upstream repository: https://github.com/LCAS/mqtt_bridge.git
- release repository: https://github.com/lcas-releases/mqtt_bridge.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.2.0-1`

## mqtt_bridge

```
* Merge pull request #2 <https://github.com/LCAS/mqtt_bridge/issues/2> from francescodelduchetto/avoid-loops
  Avoid loops in connection with the server
* do not start a new bridge in the Server if the bridge with the reverse connection is already running bcs it create loops in ros messages
* Update README.md
* improved documentation
* Contributors: Marc Hanheide, francescodelduchetto
```
