### PR TITLE
mqtt_bridge_lcas: 1.2.2-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -291,7 +291,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/mqtt_bridge.git
-      version: 1.2.1-1
+      version: 1.2.2-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_bridge_lcas` to `1.2.2-1`:

- upstream repository: https://github.com/LCAS/mqtt_bridge.git
- release repository: https://github.com/lcas-releases/mqtt_bridge.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.1`
- previous version for package: `1.2.1-1`

## mqtt_bridge

```
* Merge pull request #4 <https://github.com/LCAS/mqtt_bridge/issues/4> from LCAS/futures
  simple threading solution
* simple threading solution
* Contributors: Marc Hanheide
```
