### PR TITLE
mod_ros: 2.0.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -418,10 +418,11 @@ repositories:
       - pedsim_scenarios
       - stefmap_ros
       - stefmap_rviz_plugin
+      - whytemap_ros
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
-      version: 1.0.0-1
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ksatyaki/mod_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mod_ros` to `2.0.0-1`:

- upstream repository: https://github.com/ksatyaki/mod_ros.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.0-1`

## whytemap_ros

```
* Changes
* Add new cost function.
* Add WHyTeMapClient similar to others
* fix
* Fix bugs and add WHyTeMapServer for ROS
* Add conversion from msg to data struct and vice versa
* Add messages
* Vectorize likelihood computations
* Changes to WHyTe-map data structures
* Clang-format fix
* Add WHyTeMap. Code compiles on Ubuntu 18.04
* Contributors: Chittaranjan Swaminathan
```
