### PR TITLE
ompl_planners: 2.0.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -508,7 +508,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/ompl_planners.git
-      version: 1.0.0-1
+      version: 2.0.0-1
     source:
       test_commits: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl_planners` to `2.0.0-1`:

- upstream repository: https://github.com/ksatyaki/ompl_planners.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/ompl_planners.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.10.2`
- previous version for package: `1.0.0-1`

## ompl_mod_objectives

```
* Fix GMMT-map cost function errors
* Correct STeF-map upstream cost fn
* Small change
* Adding mixing factor to some cost objectives
* use parameter instead of constant value
* Update DTCOptimizationObjective.cpp
  Update secondary cap.
* Add threshold to mahalanobis distance
* Change
* Add a std::shared_ptr typedef
* Many changes
* Add methods to compute cost components
* Remove reverse cost
* Fix description
* Add Down-The-WHyTe OO and add CLiFF-map to UpsteamCriterion
* Contributors: Chittaranjan S Srinivas, Chittaranjan Srinivas Swaminathan, Chittaranjan Swaminathan
```

## ompl_planners_ros

```
* Change to dubins vehicle
* Add utbm map
* Add maps
* Many changes
* Remove reverse cost
* Some changes
* Change k-nearest
* Contributors: Chittaranjan S Srinivas, Chittaranjan Swaminathan
```
