### PR TITLE
mod_ros: 3.0.1-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -422,7 +422,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
-      version: 3.0.0-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/ksatyaki/mod_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mod_ros` to `3.0.1-1`:

- upstream repository: https://github.com/ksatyaki/mod_ros.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.10.3`
- previous version for package: `3.0.0-1`
