### PR TITLE
ompl_planners: 2.1.0-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -508,7 +508,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/ompl_planners.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       test_commits: true
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ompl_planners` to `2.1.0-1`:

- upstream repository: https://github.com/ksatyaki/ompl_planners.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/ompl_planners.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## ompl_mod_objectives

- No changes

## ompl_planners_ros

```
* Changes to stefmap_ros objective
* Contributors: Chittaranjan Swaminathan
```
