### PR TITLE
mod_ros: 3.1.2-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -422,7 +422,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
-      version: 3.1.1-1
+      version: 3.1.2-1
     source:
       type: git
       url: https://github.com/ksatyaki/mod_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mod_ros` to `3.1.2-1`:

- upstream repository: https://github.com/ksatyaki/mod_ros.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.1-1`

## cliffmap_ros

```
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* Add back atc data
* Contributors: Chittaranjan Swaminathan
```

## cliffmap_rviz_plugin

```
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* Contributors: Chittaranjan Swaminathan
```

## gmmtmap_ros

```
* New ATC histograms and fix GMMT client and some stefmap scripts
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* Contributors: Chittaranjan Swaminathan
```

## gmmtmap_rviz_plugin

```
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* Contributors: Chittaranjan Swaminathan
```

## pedsim_scenarios

```
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* Contributors: Chittaranjan Swaminathan
```

## stefmap_ros

```
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* New ATC histograms and fix GMMT client and some stefmap scripts
* Merge pull request #2 <https://github.com/ksatyaki/mod_ros/issues/2> from ksatyaki/sergimolina-patch-1
  bug from the parsing function corrected
* bug from the parsing function corrected
* Comments
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* Add back atc data
* Contributors: Chittaranjan Srinivas Swaminathan, Chittaranjan Swaminathan, Sergi Molina
```

## stefmap_rviz_plugin

```
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* Contributors: Chittaranjan Swaminathan
```

## whytemap_ros

```
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* Contributors: Chittaranjan Swaminathan
```
