### PR TITLE
mod_ros: 3.1.3-2 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -422,7 +422,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
-      version: 3.1.2-1
+      version: 3.1.3-2
     source:
       type: git
       url: https://github.com/ksatyaki/mod_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mod_ros` to `3.1.3-2`:

- upstream repository: https://github.com/ksatyaki/mod_ros.git
- release repository: https://gitsvn-nt.oru.se/iliad/software/releases/cliffmap_ros-release.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `3.1.2-1`

## cliffmap_ros

```
* 3.1.2
* Changelogs updated
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* Add back atc data
* 3.1.1
* Updated changelogs
* 3.1.0
* Updated changelogs
* 3.0.1
* 3.0.0
* 2.1.0
* Updated Changelogs
* 2.0.0
* don't print warning
* Add conversion from msg to data struct and vice versa
* Changes to WHyTe-map data structures
* updated cliffmpa launch files and stefmap data and scripts
* Contributors: Chittaranjan S Srinivas, Chittaranjan Swaminathan, sergimolina
```

## cliffmap_rviz_plugin

```
* 3.1.2
* Changelogs updated
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* 3.1.1
* Updated changelogs
* 3.1.0
* Updated changelogs
* 3.0.1
* 3.0.0
* 2.1.0
* Updated Changelogs
* 2.0.0
* Add WHyTeMap. Code compiles on Ubuntu 18.04
* cliffmaps things
* added stefmap things
* add proper cliffmaps for orkla
* updated cliffmpa launch files and stefmap data and scripts
* added color code to cliffmap arrows
* Contributors: Chittaranjan S Srinivas, Chittaranjan Swaminathan, sergimolina
```

## gmmtmap_ros

```
* 3.1.2
* Changelogs updated
* New ATC histograms and fix GMMT client and some stefmap scripts
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* 3.1.1
* Updated changelogs
* 3.1.0
* Updated changelogs
* Changes merged in hard... from Sergi
* 3.0.1
* 3.0.0
* 2.1.0
* Updated Changelogs
* 2.0.0
* add stuff to fix gmmt cost function
* Add option to get mixing factor
* Add WHyTeMap. Code compiles on Ubuntu 18.04
* Contributors: Chittaranjan S Srinivas, Chittaranjan Swaminathan
```

## gmmtmap_rviz_plugin

```
* 3.1.2
* Changelogs updated
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* 3.1.1
* Updated changelogs
* 3.1.0
* Updated changelogs
* 3.0.1
* 3.0.0
* 2.1.0
* Updated Changelogs
* 2.0.0
* Contributors: Chittaranjan S Srinivas, Chittaranjan Swaminathan
```

## pedsim_scenarios

```
* 3.1.2
* Changelogs updated
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* 3.1.1
* Updated changelogs
* 3.1.0
* Updated changelogs
* 3.0.1
* 3.0.0
* 2.1.0
* Updated Changelogs
* 2.0.0
* add stuff to fix gmmt cost function
* Added warehouse scenario
* Contributors: Chittaranjan S Srinivas, Chittaranjan Swaminathan
```

## stefmap_ros

```
* Fix stefmap client
* 3.1.2
* Changelogs updated
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* New ATC histograms and fix GMMT client and some stefmap scripts
* Merge pull request #2 <https://github.com/ksatyaki/mod_ros/issues/2> from ksatyaki/sergimolina-patch-1
  bug from the parsing function corrected
* bug from the parsing function corrected
* Comments
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* Add back atc data
* 3.1.1
* Updated changelogs
* Backwards compatibility fix
* 3.1.0
* Version error fix
* Updated changelogs
* Changes merged in hard... from Sergi
* Add new launch files
* 3.0.1
* 3.0.0
* fix irritating output issue
* 2.1.0
* Updated Changelogs
* 2.0.0
* Change filemod
* Add ATC histograms and scripts
* Changes
* Add dynamic reconfigure as a dep in package.xml
* Add WHyTeMap. Code compiles on Ubuntu 18.04
* added stefmap things
* added new map
* updated cliffmpa launch files and stefmap data and scripts
* modified the stefmap launch node and added a reconfigure to change the time and order of predictions
* added colors depending on direction. changed stefmap server to take also frame_id and cahnged stefmap client example
* changes to use actionlib to retrive the probabilities from fremenarray instead of using the topic publishing
* Contributors: Chittaranjan S Srinivas, Chittaranjan Srinivas Swaminathan, Chittaranjan Swaminathan, Sergi Molina, sergimolina
```

## stefmap_rviz_plugin

```
* 3.1.2
* Changelogs updated
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* 3.1.1
* Updated changelogs
* 3.1.0
* Updated changelogs
* 3.0.1
* 3.0.0
* 2.1.0
* Updated Changelogs
* 2.0.0
* added color code to cliffmap arrows
* added colors depending on direction. changed stefmap server to take also frame_id and cahnged stefmap client example
* changed rand to degree
* Contributors: Chittaranjan S Srinivas, Chittaranjan Swaminathan, Sergi Molina, sergimolina
```

## whytemap_ros

```
* 3.1.2
* Changelogs updated
* Merge branch 'master' of https://github.com/ksatyaki/mod_ros
* 3.1.1
* Updated changelogs
* 3.1.0
* Updated changelogs
* 3.0.1
* Fix dependency error
* 3.0.0
* Me idiot. Me fixx
* 2.1.0
* Updated Changelogs
* Fix GSL dependency on WHyTe
* 2.0.0
* Updated Changelogs
* Changes
* Add new cost function.
* Add WHyTeMapClient similar to others
* fix
* Fix bugs and add WHyTeMapServer for ROS
* Add conversion from msg to data struct and vice versa
* Add messages
* Vectorize likelihood computations
* Changes to WHyTe-map data structures
* Clang-format fix
* Add WHyTeMap. Code compiles on Ubuntu 18.04
* Contributors: Chittaranjan S Srinivas, Chittaranjan Swaminathan
```
