### PR TITLE
iliad_smp: 0.4.5-1 in 'kinetic/lcas-dist.yaml' [bloom]

### DIFF
--- a/kinetic/lcas-dist.yaml
+++ b/kinetic/lcas-dist.yaml
@@ -263,7 +263,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/LCAS/restricted-releases.git
-      version: 0.4.4-1
+      version: 0.4.5-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `iliad_smp` to `0.4.5-1`:

- upstream repository: https://gitsvn-nt.oru.se/palmieri/iliad_smp.git
- release repository: https://github.com/LCAS/restricted-releases.git
- distro file: `kinetic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.4.4-1`

## iliad_smp_global_planner

```
* Weight for OMPL resolution. LETHAL costs for obstacles coming from service GetPath. Locking the costmap until planning is finished.
* Contributors: Luigi Palmieri (Robert Bosch GmbH, CR/AAS3)
```
