### PR TITLE
Fixed pip warning and web.py version issue

### DIFF
--- a/lcas-rosdistro-setup.sh
+++ b/lcas-rosdistro-setup.sh
@@ -7,7 +7,7 @@ if [ $(id -u)  = "0" ]; then
       export DEBIAN_FRONTEND=noninteractive
       SUDO=""
 else
-      SUDO="sudo"
+      SUDO="sudo -H"
 fi
 
 $SUDO apt-get update
@@ -100,7 +100,8 @@ rosdep update
 
 # Nice things
 $SUDO apt-get install -y ssh openssh-server vim git python-pip tmux openvpn python-wstool
-$SUDO pip install -U tmule 
+$SUDO pip install web.py==0.51
+$SUDO pip install tmule
 
 $SUDO curl -o /usr/local/bin/rmate https://raw.githubusercontent.com/aurora/rmate/master/rmate && $SUDO chmod +x /usr/local/bin/rmate
 

--- a/lcas-rosdistro-setup.sh
+++ b/lcas-rosdistro-setup.sh
@@ -100,8 +100,7 @@ rosdep update
 
 # Nice things
 $SUDO apt-get install -y ssh openssh-server vim git python-pip tmux openvpn python-wstool
-$SUDO pip install web.py==0.51
-$SUDO pip install tmule
+$SUDO pip install -U tmule
 
 $SUDO curl -o /usr/local/bin/rmate https://raw.githubusercontent.com/aurora/rmate/master/rmate && $SUDO chmod +x /usr/local/bin/rmate
 


### PR DESCRIPTION
Just a minor change to the setup script. The script was failing because `pip install -U tmule` was trying to get the most recent version of web.py, which [has issues with python 2](https://forum.iredmail.org/post75845.html#p75845). I changed it to use the working version of web.py and removed the `-U` parameter so it would not try to upgrade. I also added the `-H` parameter to `sudo` to mollify pip.