### PR TITLE
thorvald: 2.0.0-2 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -886,7 +886,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SAGARobotics/thorvald-releases.git
-      version: 2.0.0-1
+      version: 2.0.0-2
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `2.0.0-2`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/SAGARobotics/thorvald-releases.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## thorvald

```
* melodic-1.3.2
* changelogs
* melodic-1.3.1
* changelogs
* melodic-1.3.0
* changelog
* Contributors: Marc Hanheide
```

## thorvald_2dnav

```
* melodic-1.3.2
* changelogs
* Merge pull request #111 <https://github.com/SAGARobotics/Thorvald/issues/111> from MikHut/melodic-devel
  tf_prefix fix same as #109 <https://github.com/SAGARobotics/Thorvald/issues/109> but for melodic-devel
* merge conflicts
* melodic-1.3.1
* changelogs
* melodic-1.3.0
* changelog
* Contributors: Jaime Pulido Fentanes, Marc Hanheide, c-small
```

## thorvald_base

```
* Merge pull request #121 <https://github.com/SAGARobotics/Thorvald/issues/121> from larsgrim/unified_thorvald
  reintroduced homing and controller setup
* reintroduced homing and controller setup
* Merge pull request #115 <https://github.com/SAGARobotics/Thorvald/issues/115> from larsgrim/unified_thorvald
  Unified thorvald
* removed unused deps
* removed unused deps
* de-CAN-ified battery id
* now uses battery paramter 'id'
* reintroduced battery data publishing
* updated error message
* returns false if no device
* housekeeping
* will run simulation without can paramters
* added error to explain missing parameters
* housekeeping
* now populates tf before broadcasting
* updated parameter names
* updated variable and parameter names
* updated variable names
* selectable interface + cleaning
* added class for socketcan
* replaced can_line_enc with can_line_usb
* Merge pull request #1 <https://github.com/SAGARobotics/Thorvald/issues/1> from yiannis88/lars-cleanup
  CanCtrlPltf destructor
* bool --> void setCurrentPosAsZeroAll()
* fix getBaseState push_back to resize
* initMotorDrives &setparams
* CanCtrlPltf::initBatteries refactored
* constructor base_driver while() & rm of requestNextVarsAllBatteries
* can_* cleanup - not finished
* CanCtrlPltf destructor
* added can interface type and port~
* can adapter moved from node to can_ctrl_pltf
* tx msg freq 1000->600
* fixed spelling error
* BaseState to BaseStateRos
* CAN class for no-CAN setups
* changes towards new structure WIP
* deROSification of none-node files and changes towards new structure WIP
* added main pcb CAN line class
* interface for can adapters
* melodic-1.3.2
* changelogs
* Merge pull request #111 <https://github.com/SAGARobotics/Thorvald/issues/111> from MikHut/melodic-devel
  tf_prefix fix same as #109 <https://github.com/SAGARobotics/Thorvald/issues/109> but for melodic-devel
* missed slashes that should be removed
* remove accidental change that was in thorvald_2-5_temp branch
* merge conflicts
* merge conflicts
* melodic-1.3.1
* changelogs
* melodic-1.3.0
* changelog
* Contributors: Jaime Pulido Fentanes, Lars Grimstad, Marc Hanheide, MikHut, c-small, larsgrim, yiannis88
```

## thorvald_bringup

```
* Merge pull request #115 <https://github.com/SAGARobotics/Thorvald/issues/115> from larsgrim/unified_thorvald
  Unified thorvald
* added missing use of can interface and type parameters
* added can interface and type parameters
* added default value for can_interface_type
* fixed missing namespace option and updated parameter names
* added can interface type and port~
* melodic-1.3.2
* changelogs
* Merge pull request #111 <https://github.com/SAGARobotics/Thorvald/issues/111> from MikHut/melodic-devel
  tf_prefix fix same as #109 <https://github.com/SAGARobotics/Thorvald/issues/109> but for melodic-devel
* merge conflicts
* melodic-1.3.1
* changelogs
* melodic-1.3.0
* changelog
* changed gazebo for melodic
* Contributors: Jaime Pulido Fentanes, Lars Grimstad, Marc Hanheide, c-small, larsgrim
```

## thorvald_can_devices

```
* Merge pull request #121 <https://github.com/SAGARobotics/Thorvald/issues/121> from larsgrim/unified_thorvald
  reintroduced homing and controller setup
* reintroduced homing and controller setup
* Merge pull request #115 <https://github.com/SAGARobotics/Thorvald/issues/115> from larsgrim/unified_thorvald
  Unified thorvald
* housekeeping
* removed unused deps
* now updates controller mode, controller_ok->controller_not_ok
* added updateControllerMode()
* added mode online
* now uses bat ID to set CAN addresses, voltage and curret are now double
* updated BatteryVars and de-CAN-ified bat id
* encoder values from config file
* Merge pull request #1 <https://github.com/SAGARobotics/Thorvald/issues/1> from yiannis88/lars-cleanup
  CanCtrlPltf destructor
* bool --> void setCurrentPosAsZeroAll()
* CanCtrlPltf::initBatteries refactored
* deROSification of none-node files and changes towards new structure WIP
* created interface for batteries
* added CAN frame
* melodic-1.3.2
* changelogs
* melodic-1.3.1
* changelogs
* melodic-1.3.0
* changelog
* Contributors: Lars Grimstad, Marc Hanheide, larsgrim, yiannis88
```

## thorvald_description

```
* Merge pull request #115 <https://github.com/SAGARobotics/Thorvald/issues/115> from larsgrim/unified_thorvald
  Unified thorvald
* battery parameter 'node' changed to 'id'
* melodic-1.3.2
* changelogs
* Merge pull request #111 <https://github.com/SAGARobotics/Thorvald/issues/111> from MikHut/melodic-devel
  tf_prefix fix same as #109 <https://github.com/SAGARobotics/Thorvald/issues/109> but for melodic-devel
* merge conflicts
* merge conflicts
* melodic-1.3.1
* changelogs
* Merge pull request #106 <https://github.com/SAGARobotics/Thorvald/issues/106> from MikHut/melodic-devel
  add datum file argument for GPS sim and future georeferenced simulations
* add datum file argument for GPS sim and future georeferenced simulations
* melodic-1.3.0
* changelog
* changed gazebo for melodic
* Contributors: Jaime Pulido Fentanes, Lars Grimstad, Marc Hanheide, MikHut, c-small, larsgrim
```

## thorvald_example_robots

```
* Merge pull request #115 <https://github.com/SAGARobotics/Thorvald/issues/115> from larsgrim/unified_thorvald
  Unified thorvald
* battery parameter 'node' changed to 'id'
* added can interface parameters
* melodic-1.3.2
* changelogs
* Merge pull request #111 <https://github.com/SAGARobotics/Thorvald/issues/111> from MikHut/melodic-devel
  tf_prefix fix same as #109 <https://github.com/SAGARobotics/Thorvald/issues/109> but for melodic-devel
* merge conflicts
* melodic-1.3.1
* changelogs
* melodic-1.3.0
* changelog
* Contributors: Jaime Pulido Fentanes, Lars Grimstad, Marc Hanheide, c-small, larsgrim
```

## thorvald_gazebo_plugins

```
* Merge pull request #115 <https://github.com/SAGARobotics/Thorvald/issues/115> from larsgrim/unified_thorvald
  Unified thorvald
* BaseState to BaseStateRos
* melodic-1.3.2
* changelogs
* melodic-1.3.1
* changelogs
* melodic-1.3.0
* changelog
* making code base the same for kinetic and melodic (#89 <https://github.com/SAGARobotics/Thorvald/issues/89>)
* removed old gazebo plugin and adaptation for gazebo9+ (#87 <https://github.com/SAGARobotics/Thorvald/issues/87>)
* changed gazebo for melodic
* Contributors: Lars Grimstad, Marc Hanheide, larsgrim
```

## thorvald_gui

```
* Merge pull request #115 <https://github.com/SAGARobotics/Thorvald/issues/115> from larsgrim/unified_thorvald
  Unified thorvald
* updated to work with new message structures
* melodic-1.3.2
* changelogs
* melodic-1.3.1
* changelogs
* melodic-1.3.0
* changelog
* Contributors: Lars Grimstad, Marc Hanheide, larsgrim
```

## thorvald_msgs

```
* melodic-1.3.2
* changelogs
* melodic-1.3.1
* changelogs
* melodic-1.3.0
* changelog
* Contributors: Marc Hanheide
```

## thorvald_simulator

```
* melodic-1.3.2
* changelogs
* melodic-1.3.1
* changelogs
* melodic-1.3.0
* changelog
* Contributors: Marc Hanheide
```

## thorvald_teleop

```
* Merge pull request #112 <https://github.com/SAGARobotics/Thorvald/issues/112> from Jailander/melodic-autoblock
  Addidng missing auto-block to melodic-devel
* Adding a service that allows the setting and un-setting of auto mode using ROS service interface
* typo
* forgot important line!!!
* Adding service that stops the user from being able to put the robot in auto mode
* melodic-1.3.2
* changelogs
* Merge pull request #111 <https://github.com/SAGARobotics/Thorvald/issues/111> from MikHut/melodic-devel
  tf_prefix fix same as #109 <https://github.com/SAGARobotics/Thorvald/issues/109> but for melodic-devel
* teleop launch arg value should be default
* melodic-1.3.1
* changelogs
* melodic-1.3.0
* changelog
* Contributors: Jaime Pulido Fentanes, Marc Hanheide, MikHut, jailander
```

## thorvald_twist_mux

```
* melodic-1.3.2
* changelogs
* melodic-1.3.1
* changelogs
* melodic-1.3.0
* changelog
* Contributors: Marc Hanheide
```
