### PR TITLE
thorvald: 2.1.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -877,6 +877,7 @@ repositories:
       - thorvald_can_devices
       - thorvald_description
       - thorvald_example_robots
+      - thorvald_extras
       - thorvald_gazebo_plugins
       - thorvald_gui
       - thorvald_msgs
@@ -886,7 +887,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SAGARobotics/thorvald-releases.git
-      version: 2.0.0-1
+      version: 2.1.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `2.1.0-1`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/SAGARobotics/thorvald-releases.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.0.0-1`

## thorvald

```
* Merge branch 'melodic-devel' of https://github.com/sagarobotics/Thorvald into unified_thorvald
* Contributors: Lars Grimstad
```

## thorvald_2dnav

```
* Merge branch 'melodic-devel' of https://github.com/sagarobotics/Thorvald into unified_thorvald
* Contributors: Lars Grimstad
```

## thorvald_base

```
* Merge pull request #157 <https://github.com/SAGARobotics/Thorvald/issues/157> from MikHut/melodic-devel-tiger-merge
  Hacky Melodic devel tiger merge
* Merge branch 'melodic-devel' into melodic-devel-tiger-merge
* Merge pull request #156 <https://github.com/SAGARobotics/Thorvald/issues/156> from mattkefford/melodic-devel
  Services to trigger hardware emergency stop and turn on/off laser safety feature
* Fixed syntax bug
* Updated to fit naming convention and display estop as a warning
* Merge branch 'melodic-devel-tiger-merge' of https://github.com/MikHut/Thorvald into melodic-devel-tiger-merge
* Merge branch 'melodic-devel' into melodic-devel-tiger-merge
* Update can_ctrl_pltf.cpp
  Added check of can_frames returned to account for io devices that might not return a can frame
* Corrected syntax error
* Continued adding software control of hardware estop and related safety changes
  Added sending emergency stop to all IO's in can control platform.
  Refactored safety_stop service to stop_robot.
  Added emergency_stop service to base_driver.
  Added estop service to canIO abstract class.
  Refactored lasers_ignore to laser_safety and changed service to use_laser_safety.
  Removed movement_ok and used existing D_ESTOP.
  Changed estop and laser defaults to false.
  Replaced button bit in status packet with laser_safety bit.
  Some misc refactoring/tidying/corrections.
* Merge pull request #149 <https://github.com/SAGARobotics/Thorvald/issues/149> from mattkefford/melodic-devel
  Added beacon digital IO's to allow control via enclosure PCB's
* Added default string for when there's no estop triggered.
* Update can_ctrl_pltf.h
* Tidied and refactored new estop topic changes
  Needs testing!
* Added getting of safety data from configured IO
* In progress software estop
* Adding estop topic
* Merge branch 'melodic-devel-tiger' of https://github.com/LCAS/Thorvald into meldevtig-turning
* Merge pull request #145 <https://github.com/SAGARobotics/Thorvald/issues/145> from mattkefford/tgr_fix
  Tiger fix for dropped can frames
* Increased serial buffer and increased can_frames topic queue size to 100
* Merge pull request #140 <https://github.com/SAGARobotics/Thorvald/issues/140> from mattkefford/melodic-devel
  Added quick changes to correct CRC checking and interface to V2 PCB
* enabled < 8 byte can frames
* enabled can device msgs
* increased can queue size
* Tweaks to serial port settings and added flush
  Added port flush on open.
  Close port if errors.
  Disabled IEXTEN and OCRNL flags.
  Matched ospeed to ispeed.
* Added quick changes to correct CRC checking and interface to V2 PCB
  On branch melodic-devel
  modified:   thorvald_base/CMakeLists.txt
  modified:   thorvald_base/common/include/can_ctrl_pltf.h
  new file:   thorvald_base/common/include/can_line_usb_v2.h
  new file:   thorvald_base/common/include/crc16.h
  modified:   thorvald_base/common/src/can_ctrl_pltf.cpp
  new file:   thorvald_base/common/src/can_line_usb_v2.cpp
  new file:   thorvald_base/common/src/crc16.c
  modified:   thorvald_base/ros/src/base_driver.cpp
  modified:   thorvald_bringup/launch/thorvald_example.launch
* Merge branch 'melodic-devel' into melodic-devel
* Merge branch 'melodic-devel' of https://github.com/LCAS/Thorvald into melodic-devel
* Merge pull request #126 <https://github.com/SAGARobotics/Thorvald/issues/126> from fcaponetto/joint_states
  Joint states: name space for the robot_state_publisher
* Merge remote-tracking branch 'mh/joint_states-fix' into joint_states
* Merge pull request #124 <https://github.com/SAGARobotics/Thorvald/issues/124> from larsgrim/unified_thorvald
  Unified thorvald
* added uv pcb io
* added include for uv pcb io
* housekeeping
* main and sister are now different IO types
* joint states remap temp fix
* housekeeping
* added io state publisher
* added getter for IO states
* added ios to eval can buffer
* added io state to msg function
* changed types
* id, name and version added to IO state msg
* created IO messages
* Merge branch 'melodic-devel' of https://github.com/sagarobotics/Thorvald into unified_thorvald
* enabled ROS service controlled IO modules
* Contributors: Fernando Caponetto, Jaime Pulido Fentanes, Lars Grimstad, MattKefford, Matthew Kefford, Michael Hutchinson, MikHut, larsgrim, mattkefford, yiannis88
```

## thorvald_bringup

```
* Merge branch 'melodic-devel' into melodic-devel-tiger-merge
* Merge pull request #156 <https://github.com/SAGARobotics/Thorvald/issues/156> from mattkefford/melodic-devel
  Services to trigger hardware emergency stop and turn on/off laser safety feature
* Update thorvald_example.launch
  Robots are not ready to use TVD0 because programmatically adding the new udev rule has not been rolled out yet
* Merge branch 'melodic-devel-tiger-merge' of https://github.com/MikHut/Thorvald into melodic-devel-tiger-merge
* Merge branch 'melodic-devel' into melodic-devel-tiger-merge
* Merge pull request #149 <https://github.com/SAGARobotics/Thorvald/issues/149> from mattkefford/melodic-devel
  Added beacon digital IO's to allow control via enclosure PCB's
* In progress software estop
* Merge pull request #140 <https://github.com/SAGARobotics/Thorvald/issues/140> from mattkefford/melodic-devel
  Added quick changes to correct CRC checking and interface to V2 PCB
* Added quick changes to correct CRC checking and interface to V2 PCB
  On branch melodic-devel
  modified:   thorvald_base/CMakeLists.txt
  modified:   thorvald_base/common/include/can_ctrl_pltf.h
  new file:   thorvald_base/common/include/can_line_usb_v2.h
  new file:   thorvald_base/common/include/crc16.h
  modified:   thorvald_base/common/src/can_ctrl_pltf.cpp
  new file:   thorvald_base/common/src/can_line_usb_v2.cpp
  new file:   thorvald_base/common/src/crc16.c
  modified:   thorvald_base/ros/src/base_driver.cpp
  modified:   thorvald_bringup/launch/thorvald_example.launch
* Merge branch 'melodic-devel' of https://github.com/sagarobotics/Thorvald into unified_thorvald
* Contributors: Jaime Pulido Fentanes, Lars Grimstad, MattKefford, Michael Hutchinson, MikHut, larsgrim, yiannis88
```

## thorvald_can_devices

```
* Merge branch 'melodic-devel' into melodic-devel-tiger-merge
* diff roboteq updated to work with melodic-dev
* Merge pull request #156 <https://github.com/SAGARobotics/Thorvald/issues/156> from mattkefford/melodic-devel
  Services to trigger hardware emergency stop and turn on/off laser safety feature
* Fixed syntax bug
* Removed button from digitals enum
  It has been replaced by laser_safety in the status packet
* Updated to fit naming convention and display estop as a warning
* Merge branch 'melodic-devel-tiger-merge' of https://github.com/MikHut/Thorvald into melodic-devel-tiger-merge
* Merge branch 'melodic-devel' into melodic-devel-tiger-merge
* Continued adding software control of hardware estop and related safety changes
  Added sending emergency stop to all IO's in can control platform.
  Refactored safety_stop service to stop_robot.
  Added emergency_stop service to base_driver.
  Added estop service to canIO abstract class.
  Refactored lasers_ignore to laser_safety and changed service to use_laser_safety.
  Removed movement_ok and used existing D_ESTOP.
  Changed estop and laser defaults to false.
  Replaced button bit in status packet with laser_safety bit.
  Some misc refactoring/tidying/corrections.
* Added services to set movement_ok and lasers_ignore
* Merge pull request #149 <https://github.com/SAGARobotics/Thorvald/issues/149> from mattkefford/melodic-devel
  Added beacon digital IO's to allow control via enclosure PCB's
* Token refactoring for a dummy commit
* Added SafetyState struct back to can_io_itf.h
* Tidied and refactored new estop topic changes
  Needs testing!
* In progress software estop
* Adding estop topic
* Added beacon digital IO's
  Added beacon values to digital IO's enum and map.
  Init beacon to all off.
  Added beacon values to can frame constructor.
  Added interpreting of beacon values in can frame evaluation.
  Some minor tidying.
* Merge pull request #140 <https://github.com/SAGARobotics/Thorvald/issues/140> from mattkefford/melodic-devel
  Added quick changes to correct CRC checking and interface to V2 PCB
* v2 pwr ctrl bit
* CAN setup
* Merge pull request #124 <https://github.com/SAGARobotics/Thorvald/issues/124> from larsgrim/unified_thorvald
  Unified thorvald
* added io library install target
* uv pcb io added to io library
* created uv pcb io
* created uv pcb io header
* removed type
* moved type from itf
* housekeeping
* changed digital IO mapping
* housekeeping
* housekeeping
* added more digital IOs and CAN message handling
* housekeeping
* switched to boost arrays for IMU data
* id, name and version added to state struct
* changed wording in service message
* resizing state vectors
* name change: rls -> digitals
* relay numbering now starts from 0
* created struct for digital IO, digital IO map class member
* added getter for io state
* added feedback and imu structs
* Merge branch 'melodic-devel' of https://github.com/sagarobotics/Thorvald into unified_thorvald
* enabled ROS service controlled IO modules
* library for io devices
* v1 pcb io
* header for v1 pcb io
* interface for io devices
* Contributors: Jaime Pulido Fentanes, Lars Grimstad, MattKefford, Michael Hutchinson, MikHut, Your Name, larsgrim
```

## thorvald_description

```
* Merge branch 'melodic-devel-tiger-merge' of https://github.com/MikHut/Thorvald into melodic-devel-tiger-merge
* Merge branch 'melodic-devel' into melodic-devel-tiger-merge
* Merge pull request #149 <https://github.com/SAGARobotics/Thorvald/issues/149> from mattkefford/melodic-devel
  Added beacon digital IO's to allow control via enclosure PCB's
* Tidied and refactored new estop topic changes
  Needs testing!
* In progress software estop
* Merge branch 'melodic-devel' into melodic-devel
* Merge pull request #153 <https://github.com/SAGARobotics/Thorvald/issues/153> from c-small/melodic-dev
  Updated tower mesh
* Updated tower mesh
* CAN setup
* Merge branch 'melodic-devel' into melodic-devel
* Merge branch 'melodic-devel' of https://github.com/LCAS/Thorvald into melodic-devel
* Merge pull request #126 <https://github.com/SAGARobotics/Thorvald/issues/126> from fcaponetto/joint_states
  Joint states: name space for the robot_state_publisher
* Thorvald: name space for robot_state_publisher -> /base_driver/joint_states #122 <https://github.com/SAGARobotics/Thorvald/issues/122>
* Merge pull request #124 <https://github.com/SAGARobotics/Thorvald/issues/124> from larsgrim/unified_thorvald
  Unified thorvald
* main and sister are now different IO types
* relay numbering now starts from 0
* Merge branch 'melodic-devel' of https://github.com/sagarobotics/Thorvald into unified_thorvald
* added io modules
* Contributors: Callum Small, Fernando Caponetto, Jaime Pulido Fentanes, Lars Grimstad, MattKefford, Michael Hutchinson, MikHut, Your Name, c-small, larsgrim
```

## thorvald_example_robots

```
* Merge branch 'melodic-devel' of https://github.com/sagarobotics/Thorvald into unified_thorvald
* Contributors: Lars Grimstad
```

## thorvald_extras

```
* Merge pull request #158 <https://github.com/SAGARobotics/Thorvald/issues/158> from Jailander/maintainer-version
  putting the correct Version number, Maintainer and License on thorval…
* putting the correct Version number, Maintainer and License on thorvald extras for release
* Merge pull request #157 <https://github.com/SAGARobotics/Thorvald/issues/157> from MikHut/melodic-devel-tiger-merge
  Hacky Melodic devel tiger merge
* Merge pull request #146 <https://github.com/SAGARobotics/Thorvald/issues/146> from MikHut/meldevtig-turning
  Tiger turn on spot - (update to match thorvald_2-5_temp_tiger teleop node)
* -ve right vertical axis
* Merge branch 'melodic-devel-tiger' of https://github.com/LCAS/Thorvald into meldevtig-turning
* Merge pull request #145 <https://github.com/SAGARobotics/Thorvald/issues/145> from mattkefford/tgr_fix
  Tiger fix for dropped can frames
* Increased serial buffer and increased can_frames topic queue size to 100
* Update tiger_G2_node.py
* thorvald extras files
* speed buttons melodic
* westcontrol robots tiger cont
* Contributors: Jaime Pulido Fentanes, MattKefford, Matthew Kefford, Michael Hutchinson, MikHut, jailander, jaime
```

## thorvald_gazebo_plugins

```
* Merge branch 'melodic-devel' of https://github.com/sagarobotics/Thorvald into unified_thorvald
* Contributors: Lars Grimstad
```

## thorvald_gui

```
* Merge branch 'melodic-devel' of https://github.com/sagarobotics/Thorvald into unified_thorvald
* Contributors: Lars Grimstad
```

## thorvald_msgs

```
* Merge branch 'melodic-devel' of https://github.com/sagarobotics/Thorvald into unified_thorvald
* Contributors: Lars Grimstad
```

## thorvald_simulator

```
* Merge branch 'melodic-devel' of https://github.com/sagarobotics/Thorvald into unified_thorvald
* Contributors: Lars Grimstad
```

## thorvald_teleop

```
* Merge pull request #160 <https://github.com/SAGARobotics/Thorvald/issues/160> from MikHut/melodic-devel
  home buttons can include "button function"
* home buttons can include "button function"
* Merge pull request #157 <https://github.com/SAGARobotics/Thorvald/issues/157> from MikHut/melodic-devel-tiger-merge
  Hacky Melodic devel tiger merge
* another fix for tiger turning
* another fix for tiger turning
* turning wheels before turning
* small fix
* on sport turning fix for tiger
* small fix
* use tiger bool assed to teleop node
* Merge branch 'melodic-devel-tiger' of https://github.com/LCAS/Thorvald into melodic-devel-tiger-merge
* HACK to merge branches, just ifs used in teleop node
* Merge pull request #147 <https://github.com/SAGARobotics/Thorvald/issues/147> from MikHut/tiger-us
  tiger us controller
* tiger us controller
* Merge pull request #146 <https://github.com/SAGARobotics/Thorvald/issues/146> from MikHut/meldevtig-turning
  Tiger turn on spot - (update to match thorvald_2-5_temp_tiger teleop node)
* Merge branch 'melodic-devel-tiger' of https://github.com/LCAS/Thorvald into meldevtig-turning
* small fix, turning limit
* update to match thorvald_2-5_temp teleop node
* change homing buttons tiger config
* fixed homing bug
* speed buttons melodic
* homing fix
* westcontrol robots tiger cont
* Merge pull request #140 <https://github.com/SAGARobotics/Thorvald/issues/140> from mattkefford/melodic-devel
  Added quick changes to correct CRC checking and interface to V2 PCB
* disabled homing, changed mode button
* added tiger config
* Merge pull request #136 <https://github.com/SAGARobotics/Thorvald/issues/136> from Jailander/latching
  Latching topic
* Latching topic
* Merge pull request #131 <https://github.com/SAGARobotics/Thorvald/issues/131> from MikHut/melodic-devel
  Fix set auto mode for melodic-devel
* set auto mode srv - more logical order
* fix for set_auto_mode service
* Merge branch 'melodic-devel' of https://github.com/sagarobotics/Thorvald into unified_thorvald
* alternative mapping for xbox one controller
* Contributors: Callum, Jaime Pulido Fentanes, Lars Grimstad, Michael Hutchinson, MikHut, jailander, jaime, larsgrim
```

## thorvald_twist_mux

```
* Merge branch 'melodic-devel' of https://github.com/sagarobotics/Thorvald into unified_thorvald
* Contributors: Lars Grimstad
```
