### PR TITLE
bacchus_teaching: 0.3.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -41,7 +41,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/bacchus_lcas.git
-      version: 0.2.2-1
+      version: 0.3.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `bacchus_teaching` to `0.3.0-1`:

- upstream repository: https://github.com/LCAS/bacchus_lcas.git
- release repository: https://github.com/lcas-releases/bacchus_lcas.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.2-1`

## bacchus_gazebo

```
* Removed actor plugin
* Cleanup Robotnik reference
* Merge pull request #30 <https://github.com/LCAS/bacchus_lcas/issues/30> from LCAS/fix_digital_twin_sim
  thorvald up and running - sherpa still pending (new pull request will be opened)
* fix issue with riseholme ground plane
* Add riseholme terrain model
  Extract riseholme terrain model from the downloaded 3D models file
* Merge remote-tracking branch 'origin/fix_digital_twin_sim' into fix_digital_twin_sim
* correct tf namespace for the kinect and velodyne
* Added missing dep (fake_localization)
* Added corner_laser_merger automatically launched after 20s
* Maintainer in Package.xml
* Re-enable riseholme map
* Cleaned main launch file
* Fix Thorvald navigation using move_base
* Refactoring launch files with individual ones for each platform
* Fix SINGLE Thorvald navigation
* Working status to fix tf-tree of simulated platforms
* Riseholme maps
* Correct Bacchus sensor suite
* Merge pull request #27 <https://github.com/LCAS/bacchus_lcas/issues/27> from pulver22/fix_launch_file
  The launch file atm is loading a broken riseholme sim, revert to standar
* Spawing Thorvald in the Riseholme field.
  Still getting the spawner to crash
* The launch file atm is loading a broken riseholme sim, revert to standar
* Merge pull request #25 <https://github.com/LCAS/bacchus_lcas/issues/25> from LCAS/riseholme-sim
  Simulated world of Riseholme with inclined terrain and fences
* Created a riseholme world compatible with data recorded by Michael
* Re-enable robot in the launch file
* Simulated world of Riseholme with inclined terrain and fences
* Merge pull request #13 <https://github.com/LCAS/bacchus_lcas/issues/13> from LCAS/heightmap_mesh
  Merging after passing CI! Hooray!
* Removed additional launch file and set heightmap as default world
* update vineyard_heightmap launch file
* adding heightmap models
* Merge pull request #7 <https://github.com/LCAS/bacchus_lcas/issues/7> from pulver22/robotnik-launch
  Merging after passing all the tests.
* Parametrised hokuyo + 2 sensors suites
  The test should now pass
* Laser merger required to fuse lidar and fix costmap generation
* Added sensors xacro dedicated files with macro
* Thorvald default platform + commented robot control part [not working]
* Single Launch file for Thorvald & Robotnik
* Contributors: Ibrahim, Marc Hanheide, Riccardo, Riccardo Polvara, Sergi Molina, ibrahim hroob, sergimolina
```

## bacchus_move_base

```
* Merge pull request #30 <https://github.com/LCAS/bacchus_lcas/issues/30> from LCAS/fix_digital_twin_sim
  thorvald up and running - sherpa still pending (new pull request will be opened)
* Rename Action Client
* Added corner_laser_merger automatically launched after 20s
* Maintainer in Package.xml
* Fix Thorvald navigation using move_base
* Fix SINGLE Thorvald navigation
* Merge pull request #7 <https://github.com/LCAS/bacchus_lcas/issues/7> from pulver22/robotnik-launch
  Merging after passing all the tests.
* Parametrised hokuyo + 2 sensors suites
  The test should now pass
* Laser merger required to fuse lidar and fix costmap generation
* Contributors: Ibrahim, Riccardo, Riccardo Polvara, Sergi Molina
```
