### PR TITLE
uol_cmp9767m: 0.7.0-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -1003,7 +1003,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/CMP9767M.git
-      version: 0.6.1-1
+      version: 0.7.0-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `uol_cmp9767m` to `0.7.0-1`:

- upstream repository: https://github.com/LCAS/CMP9767M.git
- release repository: https://github.com/lcas-releases/CMP9767M.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.6.1-1`

## uol_cmp9767m_base

```
* Merge pull request #62 <https://github.com/LCAS/CMP9767M/issues/62> from LCAS/bacchus
  Added dependencies on bacchus
* Added dependencies on bacchus
* Contributors: Marc Hanheide, Riccardo
```

## uol_cmp9767m_tutorial

- No changes
