### PR TITLE
bacchus_teaching: 0.3.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -41,7 +41,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/bacchus_lcas.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `bacchus_teaching` to `0.3.1-1`:

- upstream repository: https://github.com/LCAS/bacchus_lcas.git
- release repository: https://github.com/lcas-releases/bacchus_lcas.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.0-1`

## bacchus_gazebo

```
* change defaults (for teaching only)
* added smaller worlds for teaching
* removed sprayer
* Various fix (sensor frame, local costmap, enable/disable dt)
* Contributors: Marc Hanheide, Riccardo
```

## bacchus_move_base

```
* Various fix (sensor frame, local costmap, enable/disable dt)
* Contributors: Riccardo
```
