### PR TITLE
topic_compression: 0.0.2-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -912,6 +912,11 @@ repositories:
       version: melodic-devel
     status: developed
   topic_compression:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/topic_compression.git
+      version: 0.0.2-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_compression` to `0.0.2-1`:

- upstream repository: https://github.com/LCAS/topic_compression
- release repository: https://github.com/lcas-releases/topic_compression.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`

## topic_compression

```
* added install targets and very basic test
* add .gitignore
* Added clearer Python instructions in README.md
* Removed logging
* Fix inline issue
* Fixed dependancies and build issue
* Updated CMake
* Updated docker dependancies
* Added instructions
* Added initial support for topic decompression using python
* Flatten multi-dimensional arrays to uint8[] for much faster IO (x112 improvement)
* Add exported targets
* Add deps to CMakeLists to ensure msgs are built before node
* Updated ros package dependancies (removed one)
* Added traceability for the algorithm
* Added both depth and colour compression algorithms
* Initial project commit
* Contributors: Marc Hanheide, RaymondKirk
```
