### PR TITLE
bacchus_teaching: 0.3.2-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -41,7 +41,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/bacchus_lcas.git
-      version: 0.3.1-1
+      version: 0.3.2-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `bacchus_teaching` to `0.3.2-1`:

- upstream repository: https://github.com/LCAS/bacchus_lcas.git
- release repository: https://github.com/lcas-releases/bacchus_lcas.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.1-1`

## bacchus_gazebo

```
* Merge pull request #40 <https://github.com/LCAS/bacchus_lcas/issues/40> from LCAS/coarse_models
  Added new world with the coarse meshes
* Delete semantic.xacro
  This is not needed here
* Added new world with the coarse meshes
  + disable multi_sim + set the world default to the simplified models.
* Merge pull request #39 <https://github.com/LCAS/bacchus_lcas/issues/39> from pulver22/teaching-multisim
  Added support for multisim robot and various fix on tf prefix
* Fix velodyne frame and wrong robot description in rviz
* Fix test case
* Multisim seems to work + Rviz config
* Single robot does work in multisim scenario
* Working on the single robot to work in a multisim scenario
  Tf-tree looks fine but local costmap is not built and the robot is not moving
* Merge pull request #1 <https://github.com/LCAS/bacchus_lcas/issues/1> from LCAS/teaching
  Synchronise with upstream
* Merge branch 'teaching-multisim' into teaching
* Start working towards offering multisim
* Contributors: Ibrahim, Riccardo, Riccardo Polvara, pulver
```

## bacchus_move_base

```
* Merge pull request #39 <https://github.com/LCAS/bacchus_lcas/issues/39> from pulver22/teaching-multisim
  Added support for multisim robot and various fix on tf prefix
* Single robot does work in multisim scenario
* Working on the single robot to work in a multisim scenario
  Tf-tree looks fine but local costmap is not built and the robot is not moving
* Merge pull request #1 <https://github.com/LCAS/bacchus_lcas/issues/1> from LCAS/teaching
  Synchronise with upstream
* Merge branch 'teaching-multisim' into teaching
* Start working towards offering multisim
* Contributors: Riccardo, Riccardo Polvara, pulver
```
