### PR TITLE
saga_agrinav: 0.2.2-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -499,7 +499,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SAGARobotics/AgriNav-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `saga_agrinav` to `0.2.2-1`:

- upstream repository: https://github.com/SAGARobotics/AgriNav.git
- release repository: https://github.com/SAGARobotics/AgriNav-release.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.2.1-1`

## polytunnel_navigation_actions

```
* Merge pull request #62 <https://github.com/SAGARobotics/AgriNav/issues/62> from SAGARobotics/magnucha-add-missing-toponav-dep
  Add topological_navigation_msgs as a dependency
* Merge pull request #64 <https://github.com/SAGARobotics/AgriNav/issues/64> from adambinch/detector_map_switching_fix
  detector map switching fix
* detector map switching fix
* Add topological_navigation_msgs as a dependency
* Merge pull request #57 <https://github.com/SAGARobotics/AgriNav/issues/57> from MikHut/python3-devel
  Python3 friendly, works in ROS noetic and melodic now
* remove python3 dependencies from package xml
* Update RowDetector.cfg
* further changes to make python3 compatible
* python 3 friendly, to handle shebang (sudo apt-get install python-is-python3
* Contributors: Adam Binch, Magnus Harr, Michael Hutchinson, MikHut, adambinch
```
