### PR TITLE
swerve_steering_controller: 0.0.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -884,6 +884,11 @@ repositories:
       version: kinetic-devel
     status: developed
   swerve_steering_controller:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/lcas-releases/swerve_steering_controller.git
+      version: 0.0.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `swerve_steering_controller` to `0.0.1-1`:

- upstream repository: https://github.com/LCAS/swerve_steering_controller.git
- release repository: https://github.com/lcas-releases/swerve_steering_controller.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `null`
