### PR TITLE
uol_cmp9767m: 0.7.1-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -1029,7 +1029,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/CMP9767M.git
-      version: 0.7.0-1
+      version: 0.7.1-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `uol_cmp9767m` to `0.7.1-1`:

- upstream repository: https://github.com/LCAS/CMP9767M.git
- release repository: https://github.com/lcas-releases/CMP9767M.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.7.0-1`

## uol_cmp9767m_base

- No changes

## uol_cmp9767m_tutorial

```
* bind to host
* Update topo_nav.launch
  topo_localisation fix
* Merge pull request #65 <https://github.com/LCAS/CMP9767M/issues/65> from gcielniak/master
  workshop 7 - further fixes
* workshop 7 global_costmap_params fix
* Merge pull request #64 <https://github.com/LCAS/CMP9767M/issues/64> from gcielniak/master
  workshop 7 updates
* workshop 7 updates
* Merge pull request #63 <https://github.com/LCAS/CMP9767M/issues/63> from gcielniak/master
  workshop 6 scan topic fix
* workshop 6 scan topic fix
* workshop 5 update
* simple opencv test
* reduce min distance
* minor correction for new simulation
* changed for new env
* adapted for new environment
* Contributors: Grzegorz Cielniak, Marc, Marc Hanheide, gcielniak
```
