### PR TITLE
bacchus_teaching: 0.3.4-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -41,7 +41,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/bacchus_lcas.git
-      version: 0.3.3-1
+      version: 0.3.4-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `bacchus_teaching` to `0.3.4-1`:

- upstream repository: https://github.com/LCAS/bacchus_lcas.git
- release repository: https://github.com/lcas-releases/bacchus_lcas.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.3.3-1`

## bacchus_gazebo

```
* Merge pull request #43 <https://github.com/LCAS/bacchus_lcas/issues/43> from gcielniak/teaching
  fix global costmap parameters
* enable nav_map_yaml as a configurable parameter
* Enable non-paused sim + Fix depth camera_info topic
* Revert Niko's commit
* 'improve' the world ;)
* Contributors: Riccardo, Riccardo Polvara, gcielniak, nikostsagk
* Patched arg for move_base missing in hierarchical launch files
* Fix camera frame in camera_info topic
* Contributors: Riccardo, pulver
```

## bacchus_move_base

```
* Merge pull request #43 <https://github.com/LCAS/bacchus_lcas/issues/43> from gcielniak/teaching
  fix global costmap parameters
* fix global costmap parameters
* Contributors: Riccardo Polvara, gcielniak
```
