### PR TITLE
thorvald: 2.2.0-2 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -909,6 +909,7 @@ repositories:
       - thorvald_extras
       - thorvald_gazebo_plugins
       - thorvald_gui
+      - thorvald_imu
       - thorvald_msgs
       - thorvald_simulator
       - thorvald_teleop
@@ -916,7 +917,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SAGARobotics/thorvald-releases.git
-      version: 2.1.1-1
+      version: 2.2.0-2
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `thorvald` to `2.2.0-2`:

- upstream repository: https://github.com/LCAS/Thorvald.git
- release repository: https://github.com/SAGARobotics/thorvald-releases.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `2.1.1-1`

## thorvald

```
* merge
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Contributors: MikHut, c-small
```

## thorvald_2dnav

```
* merge
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Contributors: MikHut, c-small
```

## thorvald_base

```
* Merge pull request #189 <https://github.com/magnucha/Thorvald/issues/189> from mattkefford/melodic-devel
  Added service to set EEPROM params on an IO device
* Removed test code and tidied up
* Fixing build errors
* Added service and CAN packet forming for EEPROM param setting
* Merge pull request #175 <https://github.com/magnucha/Thorvald/issues/175> from saldomqui/imu-driver
  Imu driver
* added a new service called set_motors_power of type std_srvs::SetBool to switch motor drivers on or off
* motors off 500ms, min time 5 sec, checking time 100ms
* controller_array struct again as local variable for testing
* motor drivers reset. 1 sec ofk, min boot time 5c and after 0.1 sec checking period
* increasing motor driver status checking period to 1 sec and minimum time of 5 sec
* fixed issue in motor drivers reset callbac
* fixed issue in motor drivers reset callbac
* increasing motor driver status checking period to 1 sec7
* setting motors drivers to on  only if they are not ready yet
* outputing some cout msgs to debug motor drivers reset process
* check if tx can msgs have been sent before exiting with minimum waiting time of 100ms
* check if tx can msgs have been sent before exiting
* just send remaining can commands and a sleep delay after
* just send remaining can commands and a sleep delay after
* just send remaining can commands and a sleep delay after
* sending device can commands 10 times after exiting ros loop
* sending device can commands after exiting ros loop
* sending remaining can messages in buffer after exiting ros loop
* cout on return message of boolean activation service
* motor drivers are checked periodically after switching them off and on using the individual driver status flags
* AHRS gains of thorvald_imu set as parameters
* initialised sucess = false by default in IOBuzzerServiceOff
* implemented deactivation of buzzer IO at program exit. Not tested yet on the robot
* changed motor on/off service from std_srvs/Bool to std_srvs/Trigger, with two oneshot timers, one for keeping the drivers off for a short time and then switch ot on and the other for informing that motors are ready
* modified thorvald_base to implement motors power ON/OFF service
* Merge branch 'melodic-devel' of https://github.com/saldomqui/Thorvald into imu-driver
* Merge pull request #173 <https://github.com/magnucha/Thorvald/issues/173> from mattkefford/melodic-devel
  LiDAR - Trigger Reset Service
  Battery voltage fix
* Added lidar reset
  Added service and BaseDriver/CAN functions to reset lidars.
  Added CANopen SDO packet construction to v1pcb class.
  Edited estop sending.
  Some code tidying.
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Merge pull request #169 <https://github.com/magnucha/Thorvald/issues/169> from mattkefford/melodic-devel
  Small refactors
* Update can_ctrl_pltf.cpp
  Reverted test code
* Small fixes to test
  Motor controller vector size.
  PC duplicate init state.
  Tiger refactoring typo.
* merge
* Merge branch 'melodic-devel' into tiger_melodic
* Merge pull request #167 <https://github.com/magnucha/Thorvald/issues/167> from mattkefford/melodic-devel
  Added temp/humidity reading from main and sister PCBs
* Added temp/humidity reading from main and sister PCBs
  Changed IOState message from vectors to floats for temp and humidity.
  Added tpdo4 parsing to extract values.
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Contributors: MattKefford, Matthew Kefford, Michael Hutchinson, MikHut, c-small, larsgrim, mattkefford, saldomqui
```

## thorvald_bringup

```
* merge
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Contributors: MikHut, c-small
```

## thorvald_can_devices

```
* Merge pull request #189 <https://github.com/magnucha/Thorvald/issues/189> from mattkefford/melodic-devel
  Added service to set EEPROM params on an IO device
* Fixing build errors
* Added service and CAN packet forming for EEPROM param setting
* Merge pull request #175 <https://github.com/magnucha/Thorvald/issues/175> from saldomqui/imu-driver
  Imu driver
* modified thorvald_base to implement motors power ON/OFF service
* Merge branch 'melodic-devel' of https://github.com/saldomqui/Thorvald into imu-driver
* Merge pull request #173 <https://github.com/magnucha/Thorvald/issues/173> from mattkefford/melodic-devel
  LiDAR - Trigger Reset Service
  Battery voltage fix
* Update kc_battery.cpp
* Update kc_battery.cpp
* Update kc_battery.cpp
* Added lidar reset
  Added service and BaseDriver/CAN functions to reset lidars.
  Added CANopen SDO packet construction to v1pcb class.
  Edited estop sending.
  Some code tidying.
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Merge pull request #169 <https://github.com/magnucha/Thorvald/issues/169> from mattkefford/melodic-devel
  Small refactors
* Small fixes to test
  Motor controller vector size.
  PC duplicate init state.
  Tiger refactoring typo.
* merge
* Merge branch 'melodic-devel' into tiger_melodic
* Merge pull request #167 <https://github.com/magnucha/Thorvald/issues/167> from mattkefford/melodic-devel
  Added temp/humidity reading from main and sister PCBs
* Added temp/humidity reading from main and sister PCBs
  Changed IOState message from vectors to floats for temp and humidity.
  Added tpdo4 parsing to extract values.
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Contributors: MattKefford, Matthew Kefford, Michael Hutchinson, MikHut, c-small, larsgrim, mattkefford, saldomqui
```

## thorvald_description

```
* merge
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Contributors: MikHut, c-small
```

## thorvald_example_robots

```
* merge
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Contributors: MikHut, c-small
```

## thorvald_extras

```
* Merge pull request #194 <https://github.com/magnucha/Thorvald/issues/194> from MikHut/melodic-devel
  Only print connecting to tiger once when disconnected
* Only print connecting to tiger once when disconnected
* Merge pull request #191 <https://github.com/magnucha/Thorvald/issues/191> from MikHut/three-robots-one-controller
  Three robots one controller
* tiger node right joy vertical sign fix
* fix to stop overwriting butttons
* button fix
* fixes for tiger axis buttons
* add buttonify axis to tiger node
* minor tiger node fix
* three robots one controller configs
* Merge branch 'imu-driver' of https://github.com/saldomqui/Thorvald into imu-driver
* Merge branch 'melodic-devel' into imu-driver
* Merge pull request #174 <https://github.com/magnucha/Thorvald/issues/174> from c-small/tiger_melodic
  Intall tags
* added install tags for tiger script
* corrected naming convention
* Merge branch 'SAGARobotics:melodic-devel' into melodic-devel
* Merge pull request #165 <https://github.com/magnucha/Thorvald/issues/165> from c-small/tiger_melodic
  Thorvald Extras Cleanup
* dummy commit
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Merge pull request #169 <https://github.com/magnucha/Thorvald/issues/169> from mattkefford/melodic-devel
  Small refactors
* Small fixes to test
  Motor controller vector size.
  PC duplicate init state.
  Tiger refactoring typo.
* Removed tgr python package
* Swapped src and scripts content
* Merge pull request #2 <https://github.com/magnucha/Thorvald/issues/2> from MikHut/tiger_melodic
  two robot one joy merge conflicts
* merge
* merge
* Merge pull request #168 <https://github.com/magnucha/Thorvald/issues/168> from MikHut/two-robots-one-joy
  Two robots one joy
* minor fix
* minor fix
* minor fix
* multiple robot control in tiger receiver
* audio files
* thorvald audio player
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Test changes
* renamed message topic
* renaming
* Cleanup
* Added tiger Estop topic.
* Contributors: Callum Small, Jaime Pulido Fentanes, MattKefford, Matthew Kefford, Michael Hutchinson, MikHut, c-small, saldomqui
```

## thorvald_gazebo_plugins

```
* merge
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Contributors: MikHut, c-small
```

## thorvald_gui

```
* merge
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Contributors: MikHut, c-small
```

## thorvald_imu

```
* Set version in thorvald_imu package. Required for release
* Merge pull request #175 <https://github.com/magnucha/Thorvald/issues/175> from saldomqui/imu-driver
  Imu driver
* modified launch file of thorvald_imu
* some modifications related with issue #175 <https://github.com/magnucha/Thorvald/issues/175>
* AHRS gains of thorvald_imu set as parameters
* filled message and success in imu calibration service
* solved issue with serial port reading rate slower than imu data comming
* visualization marker representing the control board of thorvald robot. Conditional compilation for test imu and robt's imu
* thorvald imu merged into this branch by error, but it works
* node converted to class, calibration service changed to std_srvs/Trigger with a timeout
* set parameters for test imu
* fixed issue with euler angles values and visualization markers
* added define scale value coefficients for Saga's imu
* adjusted acceleration scale in thorvald_imu. Define the scale using MAX_ACC_G define directive in thorvald_imu_node.cpp
* adjusted acceleration scale in thorvald_imu. Define the scale using MAX_ACC_G define directive in thorvald_imu_node.cpp
* fixed issue with imu data parsing
* added some images for documentation
* created ros node to parse imu data from serial port and publish it in sensor_msgs/Imu format
* Contributors: Magnus Conrad Harr, Michael Hutchinson, saldomqui
```

## thorvald_msgs

```
* merge
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Contributors: MikHut, c-small
```

## thorvald_simulator

```
* merge
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Contributors: MikHut, c-small
```

## thorvald_teleop

```
* Update package.xml (#192 <https://github.com/magnucha/Thorvald/issues/192>)
  Added dependency for thorvald_extras
  When the tiger-controller is specified as the TELEOP_CONTROLLER in the .rasberryrc file, the thorvald_extras package must be installed.
* Merge pull request #191 <https://github.com/magnucha/Thorvald/issues/191> from MikHut/three-robots-one-controller
  Three robots one controller
* fixes for tiger axis buttons
* teleop - make deadzone a param
* add buttonify axis to tiger node
* multi robot teleop launch fix
* typo
* three robots one controller configs
* Merge pull request #187 <https://github.com/magnucha/Thorvald/issues/187> from Jailander/operation-stats
  creating /auto_mode topic
* creating /auto_mode topic
* Merge branch 'imu-driver' of https://github.com/saldomqui/Thorvald into imu-driver
* Merge branch 'melodic-devel' into imu-driver
* Merge pull request #181 <https://github.com/magnucha/Thorvald/issues/181> from MikHut/block-auto-subscriber
  Block auto via a subscriber
* Reorder initialisation of publishers and subscribers so that the publisher exists before the subscriber - whose callback for block auto uses the publisher
* Block auto via subscriber instead of service, keeps auto blocked if the node is relaunched and there is no repeat service call
* Merge branch 'SAGARobotics:melodic-devel' into melodic-devel
* Merge pull request #165 <https://github.com/magnucha/Thorvald/issues/165> from c-small/tiger_melodic
  Thorvald Extras Cleanup
* Merge pull request #2 <https://github.com/magnucha/Thorvald/issues/2> from MikHut/tiger_melodic
  two robot one joy merge conflicts
* merge
* merge
* Merge pull request #168 <https://github.com/magnucha/Thorvald/issues/168> from MikHut/two-robots-one-joy
  Two robots one joy
* multiple robot control in tiger receiver
* teleop launch for multiple robots
* teleop launch for multiple robots
* tiger multi configs
* multiple robots param added to teleop launch file
* multi robot auto manual mode
* small fix to prev commit
* small fix to prev commit
* small fix to prev commit
* change forward and left mode buttons
* Quick fix for #164 <https://github.com/magnucha/Thorvald/issues/164>
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* on sport turning fix for tiger
* Merge branch 'melodic-devel-tiger-merge' of https://github.com/MikHut/Thorvald into tiger_melodic
* Contributors: Bård-Kristian, Callum Small, Jaime Pulido Fentanes, Matthew Kefford, Michael Hutchinson, MikHut, c-small, saldomqui
```

## thorvald_twist_mux

```
* Merge branch 'imu-driver' of https://github.com/saldomqui/Thorvald into imu-driver
* Merge branch 'melodic-devel' into imu-driver
* Merge pull request #179 <https://github.com/magnucha/Thorvald/issues/179> from MikHut/melodic-devel
  add pause_autonomous_navigation topic to twist mux lock
* add pause_autonomous_navigation topic to twist mux lock
* merge
* Merge branch 'melodic-devel' of https://github.com/SAGARobotics/Thorvald into tiger_melodic
* Contributors: Michael Hutchinson, MikHut, c-small, saldomqui
```
