### PR TITLE
topic_compression: 0.0.3-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -930,7 +930,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/topic_compression.git
-      version: 0.0.2-1
+      version: 0.0.3-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `topic_compression` to `0.0.3-1`:

- upstream repository: https://github.com/LCAS/topic_compression
- release repository: https://github.com/lcas-releases/topic_compression.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `0.0.2-1`
