### PR TITLE
mqtt_bridge_lcas: 1.4.3-1 in 'melodic/lcas-dist.yaml' [bloom]

### DIFF
--- a/melodic/lcas-dist.yaml
+++ b/melodic/lcas-dist.yaml
@@ -323,7 +323,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lcas-releases/mqtt_bridge.git
-      version: 1.4.2-1
+      version: 1.4.3-1
     source:
       test_commits: true
       test_pull_requests: true


### PR DESCRIPTION
Increasing version of package(s) in repository `mqtt_bridge_lcas` to `1.4.3-1`:

- upstream repository: https://github.com/LCAS/mqtt_bridge.git
- release repository: https://github.com/lcas-releases/mqtt_bridge.git
- distro file: `melodic/lcas-dist.yaml`
- bloom version: `0.10.7`
- previous version for package: `1.4.2-1`

## mqtt_bridge

```
* Merge pull request #18 <https://github.com/LCAS/mqtt_bridge/issues/18> from LCAS/server_tweaks
  initial trials to set mosquitto server config
* make the config file an argument (and fix some timing in test)
* documenting the frequency flag
* few more defaults for broker
* initial trials to set mosquitto server config
* Contributors: Marc Hanheide
```
