### PR TITLE
topological_navigation: 3.0.1-1 in 'humble/lcas-dist.yaml' [bloom]

### DIFF
--- a/humble/lcas-dist.yaml
+++ b/humble/lcas-dist.yaml
@@ -7,6 +7,16 @@ release_platforms:
   - jammy
 repositories:
   topological_navigation:
+    release:
+      packages:
+      - bayesian_topological_localisation
+      - topological_navigation
+      - topological_navigation_msgs
+      - topological_utils
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/lcas-releases/topological_navigation.git
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/LCAS/topological_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topological_navigation` to `3.0.1-1`:

- upstream repository: https://github.com/LCAS/topological_navigation.git
- release repository: https://github.com/lcas-releases/topological_navigation.git
- distro file: `humble/lcas-dist.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`

## bayesian_topological_localisation

```
* Merge pull request #160 <https://github.com/LCAS/topological_navigation/issues/160> from Iranaphor/humble-dev
  ROS 2 / Humble - porting
* Centralising topological_navigation stack messages to msgs package. (+version number sync across packages to 3.0.0)
* Updates to Maintainers and Authors
* full build working for topological_utils
* Compilation of message files and restructuring heirarchy for ros2 compatibility
* initial work towards a working ros2 toponav
* Merge pull request #148 <https://github.com/LCAS/topological_navigation/issues/148> from gpdas/localisation_node_fix
  localisation_node waits for topomap before starting services and also fixes a "list object does not have shape" error.
* localisation_node waits for topomap before starting services
* Contributors: Gautham P Das, James Heselden, JamesH, Marc Hanheide, mobile_server
```

## topological_navigation

```
* Merge pull request #171 <https://github.com/LCAS/topological_navigation/issues/171> from GPrathap/humble-dev
  adding different bt tree for row navigation
* adding row_traversal action type
* adding different bt tree for row navigation
* Merge pull request #170 <https://github.com/LCAS/topological_navigation/issues/170> from GPrathap/humble-dev
  adding traverse through poses and updating rviz plugin
* sending correct respond code
* adding traverse through poses
* Merge pull request #169 <https://github.com/LCAS/topological_navigation/issues/169> from GPrathap/humble-dev
  adding interactive marker server impl
* updating qos level
* adding interactive marker server impl
* Merge pull request #167 <https://github.com/LCAS/topological_navigation/issues/167> from Iranaphor/humble-dev-visuals
  Scaling added to legend
* scaling added to legend
* adding rviz vis tools init
* Merge pull request #166 <https://github.com/LCAS/topological_navigation/issues/166> from GPrathap/humble-dev
  adding simple policy server
* Merge branch 'humble-dev' of github.com:GPrathap/topological_navigation into humble-dev
* adding simple policy server
* Merge pull request #165 <https://github.com/LCAS/topological_navigation/issues/165> from GPrathap/humble-dev
  Adding the following core functionalities
* Forgot another launch_pytest to fix
* Corrected launch_pytest key
* adding test dependency
* adding testng dependency
* adding integration test script for testing navigation core components
* adding feedback messages
* removing synchronous service call
* code refactoring
* adding policy action server
* adding stopping goal action
* changing action and action types
* adding action server related changes
* fixing localisation node
* Merge pull request #164 <https://github.com/LCAS/topological_navigation/issues/164> from GPrathap/humble-dev
  fixing colcon build issue
* fixing colcon build issue
* Merge pull request #162 <https://github.com/LCAS/topological_navigation/issues/162> from Iranaphor/GoalMsg_Testing
  Development work toward a working ROS2 version
* inclusion of topomap_marker2.py with functional rescaling
* Merge pull request #161 <https://github.com/LCAS/topological_navigation/issues/161> from Iranaphor/humble-dev
  Topological map manager now working under ROS2
* incorrect tab removed
* updates to scalling for floats
* topovis scaling included for larger map visualsing from a distance
* topological transform publisher
* topological map visualiser and policy mode visualisers updated to ros2
* test script renamed to prevent crashing when using colcon test
* map_manager_2 up and running
* updates to fix imports when launching map_manager_2
* Merge pull request #160 <https://github.com/LCAS/topological_navigation/issues/160> from Iranaphor/humble-dev
  ROS 2 / Humble - porting
* python script building fix for topological_navigation
* Centralising topological_navigation stack messages to msgs package. (+version number sync across packages to 3.0.0)
* Updates to Maintainers and Authors
* full build working for topological_utils
* CMakeLists changes + restructuring for topological_utils
* Compilation of message files and restructuring heirarchy for ros2 compatibility
* initial work towards a working ros2 toponav
* Merge pull request #156 <https://github.com/LCAS/topological_navigation/issues/156> from LCAS/python3_marc_greg
  Some Python3 and multi-robot fixes
* another prefix bug relevant for multi-robot
* fixed wrong prefix for closest_edges intialisation
* Merge pull request #154 <https://github.com/LCAS/topological_navigation/issues/154> from adambinch/lcas
  Auto set goal when adding an edge to the topological map
* Goal mapping config can be set as a param
* Auto set goal when adding an edge to the topological map
  If a file e.g. thorvald_navigation_actions/config/inrownavGoal.yaml exists then the map manager will automatically set the goal of the action to the goal specified in that file, when the add edge function/service is called with arg action_type set to thorvald_navigation_actions/inrownavGoal. If that arg is not set or the file does not exist then a move base type goal is assumed.
* Merge pull request #153 <https://github.com/LCAS/topological_navigation/issues/153> from adambinch/lcas
  Add visualise_map2.py as install target
* Add visualise_map2.py as install target
* Merge pull request #150 <https://github.com/LCAS/topological_navigation/issues/150> from gpdas/lcas
  exec policy mode fix
* Merge pull request #149 <https://github.com/LCAS/topological_navigation/issues/149> from adambinch/lcas
  fix exec pol.
* start exec policy from closest or current nodes only
* fix exec pol
* Merge pull request #147 <https://github.com/LCAS/topological_navigation/issues/147> from adambinch/lcas
  Wait for closest edges before creating action servers.
* Wait for closest edges before creating action servers.
* Merge pull request #146 <https://github.com/LCAS/topological_navigation/issues/146> from adambinch/lcas
  Option to disable anchors and aliases in generated topological map ya…
* Option to disable anchors and aliases in generated topological map yaml file
* Merge pull request #145 <https://github.com/LCAS/topological_navigation/issues/145> from adambinch/lcas
  Initialise class variable
* Checks that closest edges are there in nav script. Also removed msg dependencies from cmakelists as all msgs are generated in topological_navigation_msgs
* Initialise class variable
* Merge pull request #142 <https://github.com/LCAS/topological_navigation/issues/142> from adambinch/exec_pol_nav_from_edge
  Navigating from the edge works with exec policy.
* Navigating from the edge works with exec policy.
  Also topic topological_navigation/move_action_status reports whether the goal
  of the current action is the final (toponav) goal (or not).
* Merge pull request #141 <https://github.com/LCAS/topological_navigation/issues/141> from adambinch/remove_movebase_dep
  Removed move base as dependency
* Removed move base as dependency
  tf is a run depend, not a test depend.
* Removed move base as dependency
  tf is a run depend, not a test depend.
* Merge pull request #140 <https://github.com/LCAS/topological_navigation/issues/140> from SAGARobotics/lcas
  Updating credentials
* Merge pull request #9 <https://github.com/LCAS/topological_navigation/issues/9> from adambinch/lcas
  updating credentials
* updating credentials
* Merge pull request #139 <https://github.com/LCAS/topological_navigation/issues/139> from SAGARobotics/lcas
  Update LCAS branch with SAGA branch
* Map manager unit test.
  One test which tests:
  1) If the topomap is received by a subscriber.
  2) That the get_edges_between_nodes service is advertised.
  3) Whether the service returns the 2 edges in the topomap.
* map manager improvements
* Additional edge reconfigure functionality.
  By default edge reconfigure resets the param back to its original value after the edge is traversed.
  This behaviour is now optional and can be disabled in the topological map edge config by setting reset: false for a given param.
  Updated map manager services accordingly.
* update
* marker lifetime set to half hour
* Fix no goto marker mode
* fix
* clear route markers for previous route
* adding route visualisation
* adding go to node markers and some visual improvements
* toponav launch files use new map visualiser
* Map Visualiser Based on toponav 2
* update
* update
* Removing mongodb as a dependency.
  Removed from topological_navigation and topological_utils packages.
* Merge pull request #136 <https://github.com/LCAS/topological_navigation/issues/136> from adambinch/melodic-devel
  New param topological_navigation/move_base_goal sets the goal type …
* update
* update
* update
* minor change
* New param topological_navigation/move_base_goal sets the goal type of the default action move_base_name.
  Defaults to standard move base goal type if not set.
  This will stop toponav breaking if the move_base_name action does not use move base type goals.
  Also an improvement to the add/remove edge param srvs.
* Merge pull request #135 <https://github.com/LCAS/topological_navigation/issues/135> from adambinch/melodic-devel
  Create action servers at end of initialisation.
* Create action servers at end of initialisation.
* Contributors: Adam Binch, GPrathap, Gautham P Das, Jaime Pulido Fentanes, James Heselden, James R Heselden, JamesH, Marc Hanheide, gpdas
```

## topological_navigation_msgs

```
* Merge pull request #165 <https://github.com/LCAS/topological_navigation/issues/165> from GPrathap/humble-dev
  Adding the following core functionalities
* adding feedback messages
* Merge pull request #162 <https://github.com/LCAS/topological_navigation/issues/162> from Iranaphor/GoalMsg_Testing
  Development work toward a working ROS2 version
* inclusion of goal msg so as to echo ~/goal
* Merge pull request #160 <https://github.com/LCAS/topological_navigation/issues/160> from Iranaphor/humble-dev
  ROS 2 / Humble - porting
* Centralising topological_navigation stack messages to msgs package. (+version number sync across packages to 3.0.0)
* Updates to Maintainers and Authors
* full build working for topological_utils
* topological_navigation_msgs fully updated to ROS2
* initial work towards a working ros2 toponav
* Merge pull request #154 <https://github.com/LCAS/topological_navigation/issues/154> from adambinch/lcas
  Auto set goal when adding an edge to the topological map
* Auto set goal when adding an edge to the topological map
  If a file e.g. thorvald_navigation_actions/config/inrownavGoal.yaml exists then the map manager will automatically set the goal of the action to the goal specified in that file, when the add edge function/service is called with arg action_type set to thorvald_navigation_actions/inrownavGoal. If that arg is not set or the file does not exist then a move base type goal is assumed.
* Merge pull request #146 <https://github.com/LCAS/topological_navigation/issues/146> from adambinch/lcas
  Option to disable anchors and aliases in generated topological map ya…
* Option to disable anchors and aliases in generated topological map yaml file
* Merge pull request #139 <https://github.com/LCAS/topological_navigation/issues/139> from SAGARobotics/lcas
  Update LCAS branch with SAGA branch
* Additional edge reconfigure functionality.
  By default edge reconfigure resets the param back to its original value after the edge is traversed.
  This behaviour is now optional and can be disabled in the topological map edge config by setting reset: false for a given param.
  Updated map manager services accordingly.
* Contributors: Adam Binch, GPrathap, James Heselden, JamesH, Marc Hanheide
```

## topological_utils

```
* Merge pull request #160 <https://github.com/LCAS/topological_navigation/issues/160> from Iranaphor/humble-dev
  ROS 2 / Humble - porting
* Centralising topological_navigation stack messages to msgs package. (+version number sync across packages to 3.0.0)
* Updates to Maintainers and Authors
* full build working for topological_utils
* CMakeLists changes + restructuring for topological_utils
* initial work towards a working ros2 toponav
* Merge pull request #156 <https://github.com/LCAS/topological_navigation/issues/156> from LCAS/python3_marc_greg
  Some Python3 and multi-robot fixes
* python 3 fix for goal converter
* map_converter py3 compatible
* Merge pull request #154 <https://github.com/LCAS/topological_navigation/issues/154> from adambinch/lcas
  Auto set goal when adding an edge to the topological map
* Auto set goal when adding an edge to the topological map
  If a file e.g. thorvald_navigation_actions/config/inrownavGoal.yaml exists then the map manager will automatically set the goal of the action to the goal specified in that file, when the add edge function/service is called with arg action_type set to thorvald_navigation_actions/inrownavGoal. If that arg is not set or the file does not exist then a move base type goal is assumed.
* Merge pull request #152 <https://github.com/LCAS/topological_navigation/issues/152> from adambinch/lcas
  Goal Converter
* update with saga
* Merge pull request #139 <https://github.com/LCAS/topological_navigation/issues/139> from SAGARobotics/lcas
  Update LCAS branch with SAGA branch
* clear route markers for previous route
* toponav launch files use new map visualiser
* update
* Removing mongodb as a dependency.
  Removed from topological_navigation and topological_utils packages.
* Contributors: Adam Binch, James Heselden, JamesH, Marc Hanheide, adambinch
```
