### PR TITLE
topological_navigation: 3.0.2-1 in 'humble/lcas-dist.yaml' [bloom]

### DIFF
--- a/humble/lcas-dist.yaml
+++ b/humble/lcas-dist.yaml
@@ -16,7 +16,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/lcas-releases/topological_navigation.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/LCAS/topological_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topological_navigation` to `3.0.2-1`:

- upstream repository: https://github.com/LCAS/topological_navigation.git
- release repository: https://github.com/lcas-releases/topological_navigation.git
- distro file: `humble/lcas-dist.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.1-1`

## bayesian_topological_localisation

- No changes

## topological_navigation

```
* Merge pull request #174 <https://github.com/LCAS/topological_navigation/issues/174> from Iranaphor/humble-dev-dependencies
  removal of pip dependency
* removal of pip dependency
* Contributors: James R Heselden, Marc Hanheide
```

## topological_navigation_msgs

- No changes

## topological_utils

- No changes
