### PR TITLE
topological_navigation: 3.0.3-1 in 'humble/lcas-dist.yaml' [bloom]

### DIFF
--- a/humble/lcas-dist.yaml
+++ b/humble/lcas-dist.yaml
@@ -22,7 +22,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/lcas-releases/topological_navigation.git
-      version: 3.0.2-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/LCAS/topological_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topological_navigation` to `3.0.3-1`:

- upstream repository: https://github.com/LCAS/topological_navigation.git
- release repository: https://github.com/lcas-releases/topological_navigation.git
- distro file: `humble/lcas-dist.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.2-1`

## bayesian_topological_localisation

- No changes

## topological_navigation

- No changes

## topological_navigation_msgs

```
* missing dep
* Contributors: Marc Hanheide
```

## topological_utils

- No changes
