### PR TITLE
topological_navigation: 3.0.4-1 in 'humble/lcas-dist.yaml' [bloom]

### DIFF
--- a/humble/lcas-dist.yaml
+++ b/humble/lcas-dist.yaml
@@ -35,7 +35,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/lcas-releases/topological_navigation.git
-      version: 3.0.3-2
+      version: 3.0.4-1
     source:
       type: git
       url: https://github.com/LCAS/topological_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topological_navigation` to `3.0.4-1`:

- upstream repository: https://github.com/LCAS/topological_navigation.git
- release repository: https://github.com/lcas-releases/topological_navigation.git
- distro file: `humble/lcas-dist.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.3-2`

## bayesian_topological_localisation

```
* Merge branch 'humble-dev' of github.com:LCAS/topological_navigation into humble-dev
* Contributors: GPrathap
```

## topological_navigation

```
* Merge pull request #176 <https://github.com/LCAS/topological_navigation/issues/176> from GPrathap/humble-dev
  adding server config for each action
* adding server config for each action
* Merge pull request #172 <https://github.com/LCAS/topological_navigation/issues/172> from GPrathap/humble-dev
  extending the functionality of bt trees to all action types
* Merge branch 'humble-dev' of github.com:LCAS/topological_navigation into humble-dev
* adding default config files
* extending the functionality of bt trees to all action types
* Contributors: GPrathap, James Heselden
```

## topological_navigation_msgs

```
* Merge branch 'humble-dev' of github.com:LCAS/topological_navigation into humble-dev
* Contributors: GPrathap
```

## topological_utils

```
* Merge branch 'humble-dev' of github.com:LCAS/topological_navigation into humble-dev
* Contributors: GPrathap
```
