### PR TITLE
topological_navigation: 3.0.5-1 in 'humble/lcas-dist.yaml' [bloom]

### DIFF
--- a/humble/lcas-dist.yaml
+++ b/humble/lcas-dist.yaml
@@ -46,14 +46,13 @@ repositories:
   topological_navigation:
     release:
       packages:
-      - bayesian_topological_localisation
       - topological_navigation
       - topological_navigation_msgs
       - topological_utils
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/lcas-releases/topological_navigation.git
-      version: 3.0.4-1
+      version: 3.0.5-1
     source:
       type: git
       url: https://github.com/LCAS/topological_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `topological_navigation` to `3.0.5-1`:

- upstream repository: https://github.com/LCAS/topological_navigation.git
- release repository: https://github.com/lcas-releases/topological_navigation.git
- distro file: `humble/lcas-dist.yaml`
- bloom version: `0.11.2`
- previous version for package: `3.0.4-1`

## topological_navigation

- No changes

## topological_navigation_msgs

```
* Merge pull request #178 <https://github.com/LCAS/topological_navigation/issues/178> from francescodelduchetto/humble-dev
  Taking out  bayesian_topological_localisation
* removed msg not longer in this package
* removing bayesian_topological_localisation msg and srv definition
* Contributors: James Heselden, Marc Hanheide, francescodelduchetto
```

## topological_utils

- No changes
