### PR TITLE
libfranka_lcas: 0.9.2-1 in 'humble/lcas-dist.yaml' [bloom]

### DIFF
--- a/humble/lcas-dist.yaml
+++ b/humble/lcas-dist.yaml
@@ -31,6 +31,13 @@ repositories:
       version: 2324-devel
     status: developed
   libfranka_lcas:
+    release:
+      packages:
+      - libfranka
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/lcas-releases/libfranka_lcas.git
+      version: 0.9.2-1
     source:
       type: git
       url: https://github.com/LCAS/libfranka.git


### PR DESCRIPTION
Increasing version of package(s) in repository `libfranka_lcas` to `0.9.2-1`:

- upstream repository: https://github.com/LCAS/libfranka.git
- release repository: https://github.com/lcas-releases/libfranka_lcas.git
- distro file: `humble/lcas-dist.yaml`
- bloom version: `0.11.2`
- previous version for package: `null`
