### PR TITLE
ugv_sdk_ros2: 1.0.1-1 in 'humble/lcas-dist.yaml' [bloom]

### DIFF
--- a/humble/lcas-dist.yaml
+++ b/humble/lcas-dist.yaml
@@ -96,7 +96,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/lcas-releases/ugv_sdk.git
-      version: 1.0.0-1
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/LCAS/ugv_sdk.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ugv_sdk_ros2` to `1.0.1-1`:

- upstream repository: https://github.com/LCAS/ugv_sdk.git
- release repository: https://github.com/lcas-releases/ugv_sdk.git
- distro file: `humble/lcas-dist.yaml`
- bloom version: `0.11.2`
- previous version for package: `1.0.0-1`

## ugv_sdk

```
* new version
* asio is full depend
* Contributors: Marc Hanheide
```
