### PR TITLE
kiss_icp: 0.4.1-1 in 'humble/lcas-dist.yaml' [bloom]

### DIFF
--- a/humble/lcas-dist.yaml
+++ b/humble/lcas-dist.yaml
@@ -74,6 +74,17 @@ repositories:
       url: https://github.com/LCAS/hunter_ros2.git
       version: master
     status: maintained
+  kiss_icp:
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/lcas-releases/kiss-icp.git
+      version: 0.4.1-1
+    source:
+      type: git
+      url: https://github.com/LCAS/kiss-icp.git
+      version: main
+    status: maintained
   lcas_teaching:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `kiss_icp` to `0.4.1-1`:

- upstream repository: https://github.com/LCAS/kiss-icp.git
- release repository: https://github.com/lcas-releases/kiss-icp.git
- distro file: `humble/lcas-dist.yaml`
- bloom version: `0.12.0`
- previous version for package: `null`

## kiss_icp

```
* dev-container
* Cleanup ROS package.xml and CMakeLists.txt (#337 <https://github.com/LCAS/kiss-icp/issues/337>)
  Add missing system dependencies as wel
* Change target names (#327 <https://github.com/LCAS/kiss-icp/issues/327>)
  * Change target names
  * This can be reverted, but it is related
  * Fix also tbb population
  * MakeAvailable for the win
  * Revert "This can be reverted, but it is related"
  This reverts commit 59b5d21607e66883ad71fa6b3ad3463075515d4a.
* Refactor KissICP pipeline to mantain just 1 pose instead of full trajectory. Fixes #122 <https://github.com/LCAS/kiss-icp/issues/122> (#318 <https://github.com/LCAS/kiss-icp/issues/318>)
  * First draft for fixed_size_vector. Fixes #122 <https://github.com/LCAS/kiss-icp/issues/122>
  * Pose pair, many ifs go Rhaus if this works
  * New adaptive threshold based on pose vector modification
  * Now has moved also rhaus from python
  * Push new draft with no new types
  * rename
  * Fix ROS2
  * Remove unused functions from cpp
  * Reduce code lines more
  * Change names and add some more comments
  * Marry python and C++ implementations
  * remove unused headers
  * Keep copy-pasting 🤦
  * Move poses array one level up, and add new deskew function to python API
  Now I like it even better. The pipeline is in charge of managing the
  trajectory of poses, as the KISS ICP method is invariant to this.
  * Renaming of Registration types and functions
  * from current to last
  * Renaming and reshaping in Adaptive threshold
  * More cosmesis on the AdaptiveThreshold
  * Remove constexpr
  * Ciao deskew with start/end pose
  * At least inline it
  * Const correcteness
  * New ATE from Benedikt PR
  * Revert "New ATE from Benedikt PR"
  This reverts commit af201c4e96030aa6820c150987fcd83335273b7e.
  ---------
  Co-authored-by: tizianoGuadagnino <mailto:frevo93@gmail.com>
  Co-authored-by: Benedikt Mersch <mailto:benedikt.mersch@gmail.com>
* Clean leftover from merge conflicts (#301 <https://github.com/LCAS/kiss-icp/issues/301>)
  The logger should be kiss_icp_node, not odometry_Node
* Fix and improve ROS visualization (#285 <https://github.com/LCAS/kiss-icp/issues/285>)
  * Fix this madness
  Simplify implementation by debugging in an ego-centric way always.
  Since the KISS-ICP internal map is on the global coordinates, fetch the
  last ego-centric pose and apply it to the map. Seen from the
  cloud_frame_id (which is the sensor frame) everything should always work
  in terms of visualization, no matter the multi-sensor setup.
  * Now is safe to disable this by default
  * Simplify, borrow the header from the input pointcloud msg
  This actually makes the visualization closer to the Python visualizer
  * Disable path/odom visualization by default
  In the case where we are not computing the poses in an egocentric world
  (base_frame != "") and we are not publishing to the TF tree, then the
  visualization wouldn't make sense. Therefore, disable it by default
  * Changed my mind
  If someone doesn't have that particular frame defined, then the
  visualization won't work. Leave this default
  * Move responsability of handling tf frames out of Registration (#288 <https://github.com/LCAS/kiss-icp/issues/288>)
  * Move responsability of handling tf frames out of Registration
  Since with this new changes PublishOdometry is the only member that
  requieres to know the user specified target-frame, it is not necesary to
  handle all this bits.
  This makes the implementation cleaner, easier to read and reduces the
  lines of code. Now RegisterFrame is a simple callback as few months ago
  one can read in seconds.
  * typo
  * Easier to read
  * We need this for LookupTransform
  * Remove unused variable
  * Revert "Remove unused variable"
  This reverts commit 424ee901c5442ef1f1651f48079c8cbf5a3f10bf.
  * Remove unnecessary check
  * Remove unnecessary exposed utility function from ROS API
  With this change this function is not exposed (which was never the
  intention to) to the header. This way we can also "hide" this into a
  private unnamed namesapces and benefit from inlining the simple function
  into the translation unit
  * Revert "Remove unnecessary exposed utility function from ROS API"
  This reverts commit 23cd7efafd133c4f209f8575d079dee2d14702ae.
  * Revert "Remove unnecessary check"
  This reverts commit d1dcb48762392aae879e84d849c8f4b9c6e6cc10.
  * merge conflicts :0
  * Remove unnecessary exposed utility function from ROS API (#289 <https://github.com/LCAS/kiss-icp/issues/289>)
  * Move responsability of handling tf frames out of Registration
  Since with this new changes PublishOdometry is the only member that
  requieres to know the user specified target-frame, it is not necesary to
  handle all this bits.
  This makes the implementation cleaner, easier to read and reduces the
  lines of code. Now RegisterFrame is a simple callback as few months ago
  one can read in seconds.
  * typo
  * Easier to read
  * We need this for LookupTransform
  * Remove unused variable
  * Revert "Remove unused variable"
  This reverts commit 424ee901c5442ef1f1651f48079c8cbf5a3f10bf.
  * Remove unnecessary check
  * Remove unnecessary exposed utility function from ROS API
  With this change this function is not exposed (which was never the
  intention to) to the header. This way we can also "hide" this into a
  private unnamed namesapces and benefit from inlining the simple function
  into the translation unit
  * Revert "Remove unnecessary exposed utility function from ROS API"
  This reverts commit 23cd7efafd133c4f209f8575d079dee2d14702ae.
  * Remove unnecessary exposed utility function from ROS API
  With this change this function is not exposed (which was never the
  intention to) to the header. This way we can also "hide" this into a
  private unnamed namesapces and benefit from inlining the simple function
  into the translation unit
  * Revert "Remove unnecessary check"
  This reverts commit d1dcb48762392aae879e84d849c8f4b9c6e6cc10.
  ---------
  Co-authored-by: tizianoGuadagnino <mailto:frevo93@gmail.com>
  * too many merges
  * Merge Rviz and Python colors
  * Just make the default construction more clear
  ---------
  Co-authored-by: tizianoGuadagnino <mailto:frevo93@gmail.com>
* Refactor ROS parametrization (#282 <https://github.com/LCAS/kiss-icp/issues/282>)
  * Move ros params from launch file to YAML
  * Reuse arguments for debug clouds
  * Rename odometry_node to kiss_icp_node
  odometry is way to generic
  * Rename node agin
  * Voxel size is optional paramter
  * Reads better like this
  * New parameter proposal
  * Add odometry covariance to ros node (#283 <https://github.com/LCAS/kiss-icp/issues/283>)
  * Add fixed covariance to odometry msg
  * Add default value just in case
  * pre-commit
  * Expose number of icp iterations in ros (#292 <https://github.com/LCAS/kiss-icp/issues/292>)
  * Expose registration params to ROS node
  * More merge conflicts
  * Default to multithread
* Remove unnecesary path publishing pipeline (#284 <https://github.com/LCAS/kiss-icp/issues/284>)
* Auto 2257 fix double construction kiss icp cpp (#294 <https://github.com/LCAS/kiss-icp/issues/294>)
  * First stop. Remove default constructor
  Since we can't guarantee how the pipeline is going to be constructed at
  runtime is better to force the user to wrap it in a pointer type to
  avoid having a default-constructed object that "should" be modified
  later on
  * Second stop: make the only kiss_icp::pipeline::KissICP consumer use ptr
  This way we guarantee that it's constructed once the config_ has been
  properly populated
  * Last stop: rename "odometry_" for "kiss_icp_"
  * Remove unnecessary class member
  * format
  * Remove unnncesary duplicated call
  * Update utility function to accoomodate for empty timestamps
* Contributors: Ignacio Vizzo, Marc Hanheide, Tiziano Guadagnino
```
