### PR TITLE
upstream

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4993,7 +4993,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_test_datasets-release.git
-      version: 0.3.4-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_test_datasets.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -10768,7 +10768,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/turtlebot4_setup-release.git
-      version: 1.0.4-1
+      version: 1.0.5-1
     source:
       type: git
       url: https://github.com/turtlebot/turtlebot4_setup.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3016,7 +3016,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.25.10-1
+      version: 0.25.11-1
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6825,7 +6825,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_js-release.git
-      version: 0.6.4-1
+      version: 0.6.5-1
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6809,7 +6809,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees-release.git
-      version: 2.2.3-1
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1589,7 +1589,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 3.5.0-1
+      version: 3.6.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4979,7 +4979,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.5.3-1
+      version: 0.5.4-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1589,7 +1589,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 3.4.0-1
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6901,7 +6901,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros_viewer-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1317,7 +1317,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 1.1.0-2
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1332,7 +1332,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 1.0.0-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6846,7 +6846,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_js-release.git
-      version: 0.6.5-1
+      version: 0.6.6-1
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -750,7 +750,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/automatika_ros_sugar-release.git
-      version: 0.2.5-1
+      version: 0.2.6-1
     source:
       type: git
       url: https://github.com/automatika-robotics/ros-sugar.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6873,6 +6873,15 @@ repositories:
       version: devel
     status: developed
   py_trees_ros_viewer:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_ros_viewer-release.git
+      version: 0.2.4-1
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4979,7 +4979,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.5.2-1
+      version: 0.5.3-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1976,6 +1976,26 @@ repositories:
       url: https://github.com/dynamixel-community/dynamixel_hardware.git
       version: humble
     status: developed
+  dynamixel_hardware_interface:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git
+      version: humble
+    status: developed
+  dynamixel_interfaces:
+    doc:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel_interfaces.git
+      version: humble
+    source:
+      type: git
+      url: https://github.com/ROBOTIS-GIT/dynamixel_interfaces.git
+      version: humble
+    status: developed
   dynamixel_sdk:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4958,7 +4958,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1317,7 +1317,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 1.0.0-1
+      version: 1.1.0-2
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8477,7 +8477,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros_babel_fish-release.git
-      version: 0.9.6-2
+      version: 0.9.4-1
     source:
       type: git
       url: https://github.com/LOEWE-emergenCITY/ros2_babel_fish.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -11241,6 +11241,12 @@ repositories:
       url: https://github.com/ros-drivers/urg_node_msgs.git
       version: master
     status: maintained
+  urinterfaces:
+    source:
+      type: git
+      url: https://github.com/UniversalRobots/urinterfaces.git
+      version: master
+    status: developed
   usb_cam:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -9428,7 +9428,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 11.2.15-1
+      version: 11.2.16-1
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2944,13 +2944,14 @@ repositories:
       - cmake_generate_parameter_module_example
       - generate_parameter_library
       - generate_parameter_library_example
+      - generate_parameter_library_example_external
       - generate_parameter_library_py
       - generate_parameter_module_example
       - parameter_traits
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.9-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6864,6 +6864,20 @@ repositories:
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
       version: release/2.1.x
     status: maintained
+  py_trees_ros_tutorials:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_tutorials.git
+      version: devel
+    status: developed
+  py_trees_ros_viewer:
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: devel
+    status: maintained
   pybind11_json_vendor:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5529,7 +5529,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees-release.git
-      version: 2.2.1-4
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4105,7 +4105,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5545,7 +5545,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_js-release.git
-      version: 0.6.4-1
+      version: 0.6.5-1
     source:
       test_pull_requests: true
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8824,7 +8824,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/tensorrt_cmake_module-release.git
-      version: 0.0.3-4
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/tier4/tensorrt_cmake_module.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2396,7 +2396,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.36.7-1
+      version: 0.36.8-1
     source:
       test_pull_requests: true
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1029,6 +1029,21 @@ repositories:
       url: https://github.com/MetroRobots/classic_bags.git
       version: main
     status: developed
+  clearpath_config:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_config.git
+      version: jazzy
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_config-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_config.git
+      version: jazzy
+    status: maintained
   clearpath_msgs:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4133,7 +4133,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.5.3-1
+      version: 0.5.4-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6351,6 +6351,16 @@ repositories:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git
       version: jazzy
+    release:
+      packages:
+      - rmf_demos_assets
+      - rmf_demos_bridges
+      - rmf_demos_fleet_adapter
+      - rmf_demos_tasks
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/rmf_demos-release.git
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_demos.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2324,13 +2324,14 @@ repositories:
       - cmake_generate_parameter_module_example
       - generate_parameter_library
       - generate_parameter_library_example
+      - generate_parameter_library_example_external
       - generate_parameter_library_py
       - generate_parameter_module_example
       - parameter_traits
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.9-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1225,7 +1225,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 3.4.0-1
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -8154,7 +8154,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.1.6-1
+      version: 14.1.7-1
     source:
       test_pull_requests: true
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1029,6 +1029,33 @@ repositories:
       url: https://github.com/MetroRobots/classic_bags.git
       version: main
     status: developed
+  clearpath_common:
+    doc:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_common.git
+      version: humble
+    release:
+      packages:
+      - clearpath_bt_joy
+      - clearpath_common
+      - clearpath_control
+      - clearpath_customization
+      - clearpath_description
+      - clearpath_generator_common
+      - clearpath_manipulators
+      - clearpath_manipulators_description
+      - clearpath_mounts_description
+      - clearpath_platform_description
+      - clearpath_sensors_description
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/clearpath-gbp/clearpath_common-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/clearpathrobotics/clearpath_common.git
+      version: jazzy
+    status: developed
   clearpath_config:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4140,7 +4140,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola_test_datasets-release.git
-      version: 0.3.4-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_test_datasets.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -1038,7 +1038,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5558,7 +5558,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_js-release.git
-      version: 0.6.5-1
+      version: 0.6.6-1
     source:
       test_pull_requests: true
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5597,6 +5597,22 @@ repositories:
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
       version: devel
     status: developed
+  py_trees_ros_viewer:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: devel
+    release:
+      tags:
+        release: release/jazzy/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_ros_viewer-release.git
+      version: 0.2.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: devel
+    status: maintained
   pybind11_json_vendor:
     doc:
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2958,6 +2958,18 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: developed
+  hyveos_bridge:
+    source:
+      type: git
+      url: https://github.com/p2p-industries/hyveos_ros.git
+      version: main
+    status: developed
+  hyveos_msgs:
+    source:
+      type: git
+      url: https://github.com/p2p-industries/hyveos_ros_msgs.git
+      version: main
+    status: developed
   iceoryx:
     release:
       packages:

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -4118,7 +4118,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.5.2-1
+      version: 0.5.3-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -6460,7 +6460,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.9.1-1
+      version: 1.9.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2870,7 +2870,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/gz_sim_vendor-release.git
-      version: 0.0.6-1
+      version: 0.0.7-1
     source:
       test_pull_requests: true
       type: git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -2812,7 +2812,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.2.9-1
+      version: 1.2.10-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git

--- a/jazzy/distribution.yaml
+++ b/jazzy/distribution.yaml
@@ -5606,7 +5606,7 @@ repositories:
       tags:
         release: release/jazzy/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros_viewer-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5048,7 +5048,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_js-release.git
-      version: 0.6.5-1
+      version: 0.6.6-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7458,7 +7458,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 14.4.0-1
+      version: 14.4.1-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5096,7 +5096,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros_viewer-release.git
-      version: 0.2.4-1
+      version: 0.2.5-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2599,6 +2599,18 @@ repositories:
       url: https://github.com/humanoid-path-planner/hpp-fcl.git
       version: devel
     status: developed
+  hyveos_bridge:
+    source:
+      type: git
+      url: https://github.com/p2p-industries/hyveos_ros.git
+      version: main
+    status: developed
+  hyveos_msgs:
+    source:
+      type: git
+      url: https://github.com/p2p-industries/hyveos_ros_msgs.git
+      version: main
+    status: developed
   iceoryx:
     release:
       packages:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1083,7 +1083,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/control_toolbox-release.git
-      version: 3.4.0-1
+      version: 3.5.0-1
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5019,7 +5019,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees-release.git
-      version: 2.2.1-3
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5087,6 +5087,22 @@ repositories:
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
       version: devel
     status: developed
+  py_trees_ros_viewer:
+    doc:
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: devel
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/py_trees_ros_viewer-release.git
+      version: 0.2.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/splintered-reality/py_trees_ros_viewer.git
+      version: devel
+    status: developed
   pybind11_json_vendor:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6528,7 +6528,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 2.1.2-1
+      version: 2.1.3-2
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2355,7 +2355,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gz_msgs_vendor-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5051,7 +5051,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_ros-release.git
-      version: 2.2.2-3
+      version: 2.3.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1996,13 +1996,14 @@ repositories:
       - cmake_generate_parameter_module_example
       - generate_parameter_library
       - generate_parameter_library_example
+      - generate_parameter_library_example_external
       - generate_parameter_library_py
       - generate_parameter_module_example
       - parameter_traits
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/generate_parameter_library-release.git
-      version: 0.3.9-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/generate_parameter_library.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3777,7 +3777,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_test_datasets-release.git
-      version: 0.3.4-1
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_test_datasets.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2068,7 +2068,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.40.0-1
+      version: 0.40.1-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3755,7 +3755,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.5.2-1
+      version: 0.5.3-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5035,7 +5035,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/py_trees_js-release.git
-      version: 0.6.4-3
+      version: 0.6.5-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3742,7 +3742,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3755,7 +3755,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mola_lidar_odometry-release.git
-      version: 0.5.3-1
+      version: 0.5.4-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_lidar_odometry.git


### PR DESCRIPTION
This pull request includes updates to the ROS distribution metadata and repository versions. The changes involve updating version numbers for several packages and adding new repositories to the distribution files.

Updates to repository versions:

* [`humble/distribution.yaml`](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL753-R753): Updated version numbers for multiple repositories, including `automatika_ros_sugar`, `clearpath_common`, `control_toolbox`, `generate_parameter_library`, `geometry2`, `mola_lidar_odometry`, `mola_test_datasets`, `py_trees`, `py_trees_js`, `py_trees_ros`, `py_trees_ros_interfaces`, `ros2_controllers`, `ros_babel_fish`, `rviz`, and `turtlebot4_setup`. [[1]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL753-R753) [[2]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL1320-R1320) [[3]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL1335-R1335) [[4]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL1592-R1592) [[5]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dR2967-R2974) [[6]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL3018-R3039) [[7]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL4961-R4982) [[8]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL4996-R5017) [[9]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL6812-R6833) [[10]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL6828-R6849) [[11]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL6844-R6865) [[12]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL6860-R6910) [[13]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL8193-R8237) [[14]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL8436-R8480) [[15]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL9407-R9451) [[16]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL10727-R10771)

* [`jazzy/distribution.yaml`](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6L1045-R1087): Updated version numbers for multiple repositories, including `clearpath_msgs`, `control_toolbox`, `generate_parameter_library`, `geometry2`, `ign_ros2_control`, `gz_sim_vendor`, `mola_lidar_odometry`, `mola_test_datasets`, `py_trees`, `py_trees_js`, and `py_trees_ros`. [[1]](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6L1045-R1087) [[2]](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6L1213-R1255) [[3]](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6R2369-R2376) [[4]](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6L2398-R2441) [[5]](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6L2799-R2842) [[6]](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6L2830-R2873) [[7]](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6L4108-R4163) [[8]](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6L4143-R4198) [[9]](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6L5532-R5587) [[10]](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6L5548-R5603) [[11]](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6L5564-R5619)

Additions of new repositories:

* [`humble/distribution.yaml`](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dR1979-R1998): Added new repositories `dynamixel_hardware_interface`, `dynamixel_interfaces`, `py_trees_ros_tutorials`, `py_trees_ros_viewer`, and `urinterfaces`. [[1]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dR1979-R1998) [[2]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dL6860-R6910) [[3]](diffhunk://#diff-06d8e864ec414dbf75d3ec6d593a7070858d8a07684fb6b236b90e362edebf3dR11274-R11279)

* [`jazzy/distribution.yaml`](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6R1032-R1073): Added new repositories `clearpath_common`, `clearpath_config`, `hyveos_bridge`, and `hyveos_msgs`. [[1]](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6R1032-R1073) [[2]](diffhunk://#diff-580207c444f0a1f496e481bc9a963900cc939b64d8925164ecb120730a4195b6R3004-R3015)

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R9): Updated the description to reflect the two independent sets of packaging metadata used in ROS.