### PR TITLE
Add ros2_param_dumper repository to lcas-dist.yaml

### DIFF
--- a/humble/lcas-dist.yaml
+++ b/humble/lcas-dist.yaml
@@ -262,7 +262,7 @@ repositories:
       type: git
       url: https://github.com/marc-hanheide/ros2_param_dumper.git
       version: main
-    status: developed  
+    status: developed
   ros2_topic_monitor:
     source:
       type: git

--- a/humble/lcas-dist.yaml
+++ b/humble/lcas-dist.yaml
@@ -257,6 +257,12 @@ repositories:
       url: https://github.com/amieo-ra/rasberry_coordination
       version: master
     status: developed
+  ros2_param_dumper:
+    source:
+      type: git
+      url: https://github.com/marc-hanheide/ros2_param_dumper.git
+      version: main
+    status: developed  
   ros2_topic_monitor:
     source:
       type: git


### PR DESCRIPTION
This pull request includes a change to the `humble/lcas-dist.yaml` file. The change adds a new repository entry for `ros2_param_dumper`.

Repository addition:

* [`humble/lcas-dist.yaml`](diffhunk://#diff-4e961bc4f2fecde3b16b6f5f39f7a84367006c248a394cd15b3b3c70d0e90f0cR260-R265): Added `ros2_param_dumper` repository with its source details and status.