### PR TITLE
recurse submodules

### DIFF
--- a/scripts/rosdistro_analyser.py
+++ b/scripts/rosdistro_analyser.py
@@ -226,7 +226,7 @@ class CacheAnalyser:
     def __checkout(self, url, branch, name, dir):
         cmd = ["git", "clone", '--depth', '1', '--single-branch',
                '--no-checkout','--filter=tree:0',
-            #'--recurse-submodules',
+            '--recurse-submodules',
             '-b', branch, url, name]
         print('run: %s' % ' '.join(cmd), file=sys.stderr)
         check_call(cmd, cwd=dir, stderr=DEVNULL, stdout=DEVNULL)


### PR DESCRIPTION
This pull request includes a small change to the `scripts/rosdistro_analyser.py` file. The change re-enables the `--recurse-submodules` option in the `__checkout` method, which ensures that submodules are also cloned when cloning a repository.
