### PR TITLE
Update build environment to Ubuntu 22.04 and add python_mcp dependency

### DIFF
--- a/.github/workflows/build_cache.yaml
+++ b/.github/workflows/build_cache.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   generate_cache:
     name: Generating Cache
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         distro: [melodic, noetic, humble]

--- a/.github/workflows/build_cache.yaml
+++ b/.github/workflows/build_cache.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/build_cache.yaml
+++ b/.github/workflows/build_cache.yaml
@@ -24,10 +24,10 @@ jobs:
         distro: [melodic, noetic, humble]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   # checks:
   #   name: rosdistro / rosdep checks
-  #   runs-on: ubuntu-20.04
+  #   runs-on: ubuntu-22.04
   #   strategy:
   #     matrix:
   #       python-version: [3.8]

--- a/.github/workflows/sync_upstream.yaml
+++ b/.github/workflows/sync_upstream.yaml
@@ -17,6 +17,15 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0  # Fetch full history for proper merging
 
+    - name: Check current branch
+      run: |
+        CURRENT_BRANCH=$(git branch --show-current)
+        if [ "$CURRENT_BRANCH" != "master" ]; then
+          echo "::error::This workflow should only run on the master branch. Current branch: $CURRENT_BRANCH"
+          exit 1
+        fi
+        echo "Running on master branch - proceeding with sync"
+
     - name: Configure Git
       run: |
         git config user.name "github-actions[bot]"

--- a/.github/workflows/sync_upstream.yaml
+++ b/.github/workflows/sync_upstream.yaml
@@ -1,0 +1,53 @@
+---
+name: Sync from Upstream
+on:
+  schedule:
+    # Run every Saturday at 1:00 AM UTC
+    - cron: '0 1 * * 6'
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  sync:
+    name: Sync from upstream/master
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 0  # Fetch full history for proper merging
+
+    - name: Configure Git
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@lcas.group"
+
+    - name: Add upstream remote
+      run: |
+        git remote add upstream https://github.com/ros/rosdistro.git
+        git fetch upstream
+
+    - name: Merge upstream changes
+      run: |
+        git merge upstream/master --no-edit
+      continue-on-error: false
+
+    - name: Push merged changes
+      run: |
+        git push origin master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create summary
+      if: success()
+      run: |
+        echo "Successfully synced from upstream/master" >> $GITHUB_STEP_SUMMARY
+        echo "Merged commits:" >> $GITHUB_STEP_SUMMARY
+        git log --oneline HEAD~10..HEAD >> $GITHUB_STEP_SUMMARY
+
+    - name: Handle merge conflicts
+      if: failure()
+      run: |
+        echo "Merge conflicts detected or other error occurred" >> $GITHUB_STEP_SUMMARY
+        echo "Manual intervention required" >> $GITHUB_STEP_SUMMARY
+        echo "::error::Failed to merge upstream changes. Manual resolution needed."

--- a/.github/workflows/sync_upstream.yaml
+++ b/.github/workflows/sync_upstream.yaml
@@ -3,7 +3,7 @@ name: Sync from Upstream
 on:
   schedule:
     # Run every Saturday at 1:00 AM UTC
-    - cron: '0 1 * * 6'
+  - cron: '0 1 * * 6'
   workflow_dispatch:  # Allow manual triggering
 
 jobs:

--- a/rosdep/lcas.yaml
+++ b/rosdep/lcas.yaml
@@ -86,6 +86,10 @@ prism-robots:
     xenial: [prism-robots]
 pybayes:
   ubuntu: [python-pybayes]
+python_mcp:
+  ubuntu:
+    pip:
+      packages: [mcp]
 python-munkres:
   ubuntu: [python-munkres]
 python-pydispatcher:


### PR DESCRIPTION
This pull request includes updates to workflows and dependency configurations to modernize the environment and add new package support.

### Workflow updates:
* [`.github/workflows/build_cache.yaml`](diffhunk://#diff-efda2253b02690fece5ff7a9c7ea87703cde3aa47d9916db7768ecfb60e3d099L21-R21): Updated the `runs-on` field to use `ubuntu-22.04` instead of `ubuntu-20.04` for generating cache jobs.
* [`.github/workflows/build_test.yaml`](diffhunk://#diff-70770e65d5d7633e6d0f26ffd9a93b4b75dcc940311957eac1a717fdcbf1299dL15-R15): Updated the `runs-on` field to use `ubuntu-22.04` instead of `ubuntu-20.04` for testing jobs.

### Dependency configuration:
* [`rosdep/lcas.yaml`](diffhunk://#diff-2ce41dd072bfc0cc95aa9992f5bbcec6cf53b8771f41f02ef42f68cad151b8faR89-R92): Added support for the `python_mcp` package via pip under the `ubuntu` distribution.