### PR TITLE
feat: add aoc_ros2_calib repository to distribution file

### DIFF
--- a/humble/lcas-dist.yaml
+++ b/humble/lcas-dist.yaml
@@ -42,6 +42,12 @@ repositories:
       url: https://github.com/LCAS/aoc_robot_boundary_checker.git
       version: humble_dev
     status: developed
+  aoc_ros2_calib:
+    source:
+      type: git
+      url: https://github.com/LCAS/aoc_ros2_calib.git
+      version: main
+    status: developed
   aoc_safety:
     source:
       type: git
@@ -59,7 +65,7 @@ repositories:
       type: git
       url: https://github.com/LCAS/aoc_tomato_farm.git
       version: main
-    status: developed
+    status: maintained
   autonomy_metrics_logger:
     source:
       type: git

--- a/humble/lcas-dist.yaml
+++ b/humble/lcas-dist.yaml
@@ -47,7 +47,7 @@ repositories:
       type: git
       url: https://github.com/LCAS/aoc_ros2_calib.git
       version: main
-    status: developed
+    status: maintained
   aoc_safety:
     source:
       type: git
@@ -65,7 +65,7 @@ repositories:
       type: git
       url: https://github.com/LCAS/aoc_tomato_farm.git
       version: main
-    status: maintained
+    status: developed
   autonomy_metrics_logger:
     source:
       type: git


### PR DESCRIPTION
This pull request adds a new repository entry to the `humble/lcas-dist.yaml` file to include the `aoc_ros2_calib` package. This change ensures that the distribution now tracks and maintains the calibration package from its upstream source.